### PR TITLE
track applied patches and only remove/redownload/re-patch package if patchset changed

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -94,11 +94,20 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $tmp_patches = array_merge_recursive($tmp_patches, $patches);
       }
 
+      // Remove packages for which the patch set has changed.
       foreach ($packages as $package) {
-        if (!($package instanceof AliasPackage) && array_key_exists($package->getName(), $tmp_patches) && !empty($tmp_patches[$package->getName()])) {
-          $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
-          $this->io->write('<info>Removing package ' . $package->getName() . ' so that it can be re-installed and re-patched.</info>');
-          $installationManager->uninstall($localRepository, $uninstallOperation);
+        if (!($package instanceof AliasPackage)) {
+          $package_name = $package->getName();
+          $extra = $package->getExtra();
+          $has_patches = isset($tmp_patches[$package_name]);
+          $has_applied_patches = isset($extra['patches_applied']);
+          if (($has_patches && !$has_applied_patches)
+            || (!$has_patches && $has_applied_patches)
+            || ($has_patches && $has_applied_patches && $tmp_patches[$package_name] !== $extra['patches_applied'])) {
+            $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
+            $this->io->write('<info>Removing package ' . $package_name . ' so that it can be re-installed and re-patched.</info>');
+            $installationManager->uninstall($localRepository, $uninstallOperation);
+          }
         }
       }
     }
@@ -160,18 +169,17 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   public function postInstall(PackageEvent $event) {
     // Get the package object for the current operation.
     $operation = $event->getOperation();
+    /** @var PackageInterface $package */
     $package = $this->getPackageFromOperation($operation);
-
-    /**
-     * @var PackageInterface $package
-     */
     $package_name = $package->getName();
+
     if (!isset($this->patches[$package_name])) {
       if ($this->io->isVerbose()) {
         $this->io->write('<info>No patches found for ' . $package_name . '.</info>');
       }
       return;
     }
+    $this->io->write('  - Applying patches for <info>' . $package_name . '</info>');
 
     // Get the install path from the package object.
     $manager = $event->getComposer()->getInstallationManager();
@@ -180,18 +188,25 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // Set up a downloader.
     $downloader = new RemoteFilesystem($this->io, $this->composer->getConfig());
 
-    $this->io->write('  - Applying patches for <info>' . $package_name . '</info>');
+    // Track applied patches in the package info in installed.json
+    $localRepository = $this->composer->getRepositoryManager()->getLocalRepository();
+    $localPackage = $localRepository->findPackage($package_name, $package->getVersion());
+    $extra = $localPackage->getExtra();
+    $extra['patches_applied'] = [];
+
     foreach ($this->patches[$package_name] as $description => $url) {
       $this->io->write('    <info>' . $url . '</info> (<comment>' . $description. '</comment>)');
       try {
         $this->getAndApplyPatch($downloader, $install_path, $url);
+        $extra['patches_applied'][$description] = $url;
       }
       catch (Exception $e) {
         $this->io->write('   <error>Could not apply patch! Skipping.</error>');
       }
     }
-    $this->io->write('');
+    $localPackage->setExtra($extra);
 
+    $this->io->write('');
     $this->writePatchReport($this->patches[$package_name], $install_path);
   }
 


### PR DESCRIPTION
This writes ['extra']['patches_applied'] for each patched package in vendor/composer/installed.json, and uses the information to determine whether a package should be removed/redownloaded/repatched, to avoid doing that on every "composer install"