### PR TITLE
check patches also on composer update

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -63,6 +63,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return [
       ScriptEvents::PRE_INSTALL_CMD => "checkPatches",
+      ScriptEvents::PRE_UPDATE_CMD => "checkPatches",
       PackageEvents::PRE_PACKAGE_INSTALL => "gatherPatches",
       PackageEvents::PRE_PACKAGE_UPDATE => "gatherPatches",
       PackageEvents::POST_PACKAGE_INSTALL => "postInstall",


### PR DESCRIPTION
checkPatches() is there so that a package gets re-doawnloaded and repatched if its patch set changes, even if we keep the same version of the module.

This case applies also on composer update - we want to reapply patches if they changed, iven if the "update" doesn't bring a new version of the package.