### PR TITLE
Documentation update: post-package-install is no longer necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Example composer.json:
 
 ```
 
-Note that the post-package-install part is mandatory for now. For some reason, Composer didn't invoke my event listeners, so we're going with the faster option.
-
 ## Using an external patch file
 
 Instead of a patches key in your root composer.json, use a patches-file key.


### PR DESCRIPTION
In my testing, and as shown in the rest of the README, the post-package-install directive does not appear to be required inside the composer.json file with this patch manager any longer.