### PR TITLE
Add optional git support

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -219,7 +219,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     if ($this->useGit) {
       // Commit the package.
       $this->io->write('  - Committing <info>' . $package_name . '</info> with version <info>' . $package->getVersion(). '</info> to GIT.');
-      $this->executeCommand('cd %s && git add -A . && git commit -m "%sUpdate package %s to version %s"', $install_path, $this->gitCommitMessagePrefix, $package_name, $package->getVersion());
+      $this->executeCommand('cd %s && git add -A . && git commit -m "' . $this->gitCommitMessagePrefix . 'Update package %s to version %s"', $install_path, $package_name, $package->getVersion());
     }
 
     if (!isset($this->patches[$package_name])) {
@@ -245,7 +245,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $this->getAndApplyPatch($downloader, $install_path, $url);
         if ($this->useGit) {
           $this->io->write('  - Committing patch <info>' . $url . '</info> for package <info>' . $package_name . '</info> to GIT.');
-          $this->executeCommand('cd %s && git add -A . && git commit -m "%sApplied patch %s for %s."', $install_path, $this->gitCommitMessagePrefix, $url, $package_name);
+          $this->executeCommand('cd %s && git add -A . && git commit -m "' . $this->gitCommitMessagePrefix . 'Applied patch %s for %s."', $install_path, $url, $package_name);
         }
         $extra['patches_applied'][$description] = $url;
       }

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -213,6 +213,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     if ($this->useGit) {
       // Commit the package.
+      $this->io->write('  - Committing <info>' . $package_name . '</info> with version <info>' . $package->getVersion(). '</info> to GIT.');
       $this->executeCommand('cd %s && git add -A . && git commit -m "Update package %s to version %s"', $install_path, $package_name, $package->getVersion());
     }
 
@@ -238,6 +239,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       try {
         $this->getAndApplyPatch($downloader, $install_path, $url);
         if ($this->useGit) {
+          $this->io->write('  - Committing patch <info>' . $url . '</info> for package <info>' . $package_name . '</info> to GIT.');
           $this->executeCommand('cd %s && git add -A . && git commit -m "Applied patch %s for %s."', $install_path, $url, $package_name);
         }
         $extra['patches_applied'][$description] = $url;

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -46,7 +46,11 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   /**
    * @var bool $useGit
    */
-  protected $useGit = FALSE;
+  protected $useGit;
+  /**
+   * @var string $git
+   */
+  protected $gitCommitMessagePrefix;
 
   /**
    * Apply plugin modifications to composer
@@ -60,6 +64,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $this->executor = new ProcessExecutor($this->io);
     $this->patches = array();
     $this->useGit = getenv('COMPOSER_PATCHES_USE_GIT') == '1';
+    $this->gitCommitMessagePrefix = getenv('COMPOSER_PATCHES_GIT_COMMIT_MESSAGE_PREFIX');
   }
 
   /**
@@ -214,7 +219,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     if ($this->useGit) {
       // Commit the package.
       $this->io->write('  - Committing <info>' . $package_name . '</info> with version <info>' . $package->getVersion(). '</info> to GIT.');
-      $this->executeCommand('cd %s && git add -A . && git commit -m "Update package %s to version %s"', $install_path, $package_name, $package->getVersion());
+      $this->executeCommand('cd %s && git add -A . && git commit -m "%sUpdate package %s to version %s"', $install_path, $this->gitCommitMessagePrefix, $package_name, $package->getVersion());
     }
 
     if (!isset($this->patches[$package_name])) {
@@ -240,7 +245,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $this->getAndApplyPatch($downloader, $install_path, $url);
         if ($this->useGit) {
           $this->io->write('  - Committing patch <info>' . $url . '</info> for package <info>' . $package_name . '</info> to GIT.');
-          $this->executeCommand('cd %s && git add -A . && git commit -m "Applied patch %s for %s."', $install_path, $url, $package_name);
+          $this->executeCommand('cd %s && git add -A . && git commit -m "%sApplied patch %s for %s."', $install_path, $this->gitCommitMessagePrefix, $url, $package_name);
         }
         $extra['patches_applied'][$description] = $url;
       }


### PR DESCRIPTION
This adds very basic and optional git support to composer-patches.

The use case is that we want the history of the patches be visible in the GIT history.

Also having each package committed separately is a nice side-effect.

To use:

```
export COMPOSER_PATCHES_USE_GIT=1
export COMPOSER_PATCHES_GIT_COMMIT_MESSAGE_PREFIX="Ticket #12345: "
composer install
```