### PR TITLE
Introduce error handling and DRY when getting patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -87,7 +87,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $installationManager = $this->composer->getInstallationManager();
       $packages = $localRepository->getPackages();
 
-      $tmp_patches = array();
       $tmp_patches = $this->grabPatches();
       if ($tmp_patches == FALSE) {
         $this->io->write('<info>No patches supplied.</info>');
@@ -181,31 +180,31 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       return $patches;
     }
     // If it's not specified there, look for a patches-file definition.
-    else if (isset($extra['patches-file'])) {
+    elseif (isset($extra['patches-file'])) {
       $this->io->write('<info>Gathering patches from patch file.</info>');
       $patches = file_get_contents($extra['patches-file']);
       $patches = json_decode($patches, TRUE);
       $error = json_last_error();
-        if ($error != 0) {
-          switch ($error) {
-            case JSON_ERROR_DEPTH:
-              $msg = ' - Maximum stack depth exceeded';
-              break;
-            case JSON_ERROR_STATE_MISMATCH:
-              $msg =  ' - Underflow or the modes mismatch';
-              break;
-            case JSON_ERROR_CTRL_CHAR:
-              $msg = ' - Unexpected control character found';
-              break;
-            case JSON_ERROR_SYNTAX:
-              $msg =  ' - Syntax error, malformed JSON';
-              break;
-            case JSON_ERROR_UTF8:
-              $msg =  ' - Malformed UTF-8 characters, possibly incorrectly encoded';
-              break;
-            default:
-              $msg =  ' - Unknown error';
-              break;
+      if ($error != 0) {
+        switch ($error) {
+          case JSON_ERROR_DEPTH:
+            $msg = ' - Maximum stack depth exceeded';
+            break;
+          case JSON_ERROR_STATE_MISMATCH:
+            $msg =  ' - Underflow or the modes mismatch';
+            break;
+          case JSON_ERROR_CTRL_CHAR:
+            $msg = ' - Unexpected control character found';
+            break;
+          case JSON_ERROR_SYNTAX:
+            $msg =  ' - Syntax error, malformed JSON';
+            break;
+          case JSON_ERROR_UTF8:
+            $msg =  ' - Malformed UTF-8 characters, possibly incorrectly encoded';
+            break;
+          default:
+            $msg =  ' - Unknown error';
+            break;
           }
           throw new \Exception('There was an error in the supplied patches file:' . $msg);
         }
@@ -213,7 +212,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $patches = $patches['patches'];
         return $patches;
       }
-      else if(!$patches) {
+      elseif(!$patches) {
         throw new \Exception('There was an error in the supplied patch file');
       }
     }

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -88,24 +88,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $packages = $localRepository->getPackages();
 
       $tmp_patches = array();
-
-      // First, try to get the patches from the root composer.json.
-      $extra = $this->composer->getPackage()->getExtra();
-      if (isset($extra['patches'])) {
-        $this->io->write('<info>Gathering patches for root package.</info>');
-        $tmp_patches = $extra['patches'];
-      }
-      // If it's not specified there, look for a patches-file definition.
-      else if (isset($extra['patches-file'])) {
-        $this->io->write('<info>Gathering patches from patch file.</info>');
-        $patches = file_get_contents($extra['patches-file']);
-        $patches = json_decode($patches, TRUE);
-        if (isset($patches['patches'])) {
-          $tmp_patches = $patches['patches'];
-        }
-      }
-      else {
-        // @todo: should we throw an exception here?
+      $tmp_patches = $this->grabPatches();
+      if ($tmp_patches == FALSE) {
+        $this->io->write('<info>No patches supplied.</info>');
         return;
       }
 
@@ -150,23 +135,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       return;
     }
 
-    // First, try to get the patches from the root composer.json.
-    $extra = $this->composer->getPackage()->getExtra();
-    if (isset($extra['patches'])) {
-      $this->io->write('<info>Gathering patches for root package.</info>');
-      $this->patches = $extra['patches'];
-    }
-    // If it's not specified there, look for a patches-file definition.
-    else if (isset($extra['patches-file'])) {
-      $this->io->write('<info>Gathering patches from patch file.</info>');
-      $patches = file_get_contents($extra['patches-file']);
-      $patches = json_decode($patches, TRUE);
-      if (isset($patches['patches'])) {
-        $this->patches = $patches['patches'];
-      }
-    }
-    else {
-      // @todo: should we throw an exception here?
+    $this->patches = $this->grabPatches();
+    if ($this->patches == FALSE) {
+      $this->io->write('<info>No patches supplied.</info>');
       return;
     }
 
@@ -194,6 +165,61 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // Make sure we don't gather patches again. Extra keys in $this->patches
     // won't hurt anything, so we'll just stash it there.
     $this->patches['_patchesGathered'] = TRUE;
+  }
+  
+  /**
+   * Get the patches from root composer or external file
+   * @return Patches
+   * @throws \Exception
+   */
+  public function grabPatches() {
+      // First, try to get the patches from the root composer.json.
+    $extra = $this->composer->getPackage()->getExtra();
+    if (isset($extra['patches'])) {
+      $this->io->write('<info>Gathering patches for root package.</info>');
+      $patches = $extra['patches'];
+      return $patches;
+    }
+    // If it's not specified there, look for a patches-file definition.
+    else if (isset($extra['patches-file'])) {
+      $this->io->write('<info>Gathering patches from patch file.</info>');
+      $patches = file_get_contents($extra['patches-file']);
+      $patches = json_decode($patches, TRUE);
+      $error = json_last_error();
+        if ($error != 0) {
+          switch ($error) {
+            case JSON_ERROR_DEPTH:
+              $msg = ' - Maximum stack depth exceeded';
+              break;
+            case JSON_ERROR_STATE_MISMATCH:
+              $msg =  ' - Underflow or the modes mismatch';
+              break;
+            case JSON_ERROR_CTRL_CHAR:
+              $msg = ' - Unexpected control character found';
+              break;
+            case JSON_ERROR_SYNTAX:
+              $msg =  ' - Syntax error, malformed JSON';
+              break;
+            case JSON_ERROR_UTF8:
+              $msg =  ' - Malformed UTF-8 characters, possibly incorrectly encoded';
+              break;
+            default:
+              $msg =  ' - Unknown error';
+              break;
+          }
+          throw new \Exception('There was an error in the supplied patches file:' . $msg);
+        }
+      if (isset($patches['patches'])) {
+        $patches = $patches['patches'];
+        return $patches;
+      }
+      else if(!$patches) {
+        throw new \Exception('There was an error in the supplied patch file');
+      }
+    }
+    else {
+      return FALSE;
+    }
   }
 
   /**


### PR DESCRIPTION
Composer has its own error handling for the Composer JSON file but we need it for our external patches file as well. This patch introduces that error handling, some general error handling and stops the module failing silently. Also introduced some DRY to the functions.