### PR TITLE
Patches defined in dependencies are not applied unless the dependency is updated.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -60,6 +60,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $this->eventDispatcher = $composer->getEventDispatcher();
     $this->executor = new ProcessExecutor($this->io);
     $this->patches = array();
+    $this->installedPatches = array();
   }
 
   /**
@@ -95,6 +96,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
       foreach ($packages as $package) {
         $extra = $package->getExtra();
+        if (isset($extra['patches'])) {
+          $this->installedPatches[$package->getName()] = $extra['patches'];
+        }
         $patches = isset($extra['patches']) ? $extra['patches'] : array();
         $tmp_patches = array_merge_recursive($tmp_patches, $patches);
       }
@@ -150,7 +154,16 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         if (isset($extra['patches'])) {
           $this->patches = array_merge_recursive($this->patches, $extra['patches']);
         }
+        // Unset installed patches for this package
+        if(isset($this->installedPatches[$package->getName()])) {
+          unset($this->installedPatches[$package->getName()]);
+        }
       }
+    }
+
+    // Merge installed patches from dependencies that did not receive an update.
+    foreach ($this->installedPatches as $patches) {
+      $this->patches = array_merge_recursive($this->patches, $patches);
     }
 
     // If we're in verbose mode, list the projects we're going to patch.
@@ -165,7 +178,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // won't hurt anything, so we'll just stash it there.
     $this->patches['_patchesGathered'] = TRUE;
   }
-  
+
   /**
    * Get the patches from root composer or external file
    * @return Patches


### PR DESCRIPTION
I've been struggling to rebuild a project of ours that defines patches for drupal modules in a custom drupal profile. The patch gathering process was only reading patches from the root package and packages that receive an update or install. The modified plugin in this PR stores patches definition in installed.json in $this->installedPatches, then adds them to the patch list unless the package that installed them is itself updated.