### PR TITLE
Throw a new exception after catching Cannot apply patch , so that Com…

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -263,7 +263,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
       catch (\Exception $e) {
         $this->io->write('   <error>Could not apply patch! Skipping.</error>');
-        throw new \Exception("Cannot apply patch $url");
+        if(getenv('COMPOSER_EXIT_ON_PATCH_FAILURE')) {
+          throw new \Exception("Cannot apply patch $url");
+        }
       }
     }
     $localPackage->setExtra($extra);

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -263,6 +263,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
       catch (\Exception $e) {
         $this->io->write('   <error>Could not apply patch! Skipping.</error>');
+        throw new \Exception("Cannot apply patch $url");
       }
     }
     $localPackage->setExtra($extra);


### PR DESCRIPTION
### Problem
When a patch fails, an exception is thrown from: https://github.com/cweagans/composer-patches/blob/master/src/Patches.php#L349

The exception is then catched in https://github.com/cweagans/composer-patches/blob/master/src/Patches.php#L264

During the Composer install, the patch fails to be applied and the user is informed about the error, but the install process continues.

### Expected Result
If a patch fails to be applied, an exception should be thrown so that Composer fails the install and the user is notified about the error. Today, if the Composer installs several packages, the user might not wait for the entire install to finish and might therefor miss that a patch failed.