### PR TITLE
Dependencies' patches are ignored if the root package does not define any

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -137,7 +137,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $this->patches = $this->grabPatches();
     if ($this->patches == FALSE) {
       $this->io->write('<info>No patches supplied.</info>');
-      return;
     }
 
     // Now add all the patches from dependencies that will be installed.

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -81,6 +81,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    * @param Event $event
    */
   public function checkPatches(Event $event) {
+    if (!$this->isPatchingEnabled()) {
+      return;
+    }
+
     try {
       $repositoryManager = $this->composer->getRepositoryManager();
       $localRepository = $repositoryManager->getLocalRepository();
@@ -131,6 +135,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   public function gatherPatches(PackageEvent $event) {
     // If we've already done this, then don't do it again.
     if (isset($this->patches['_patchesGathered'])) {
+      return;
+    }
+    // If patching has been disabled, bail out here.
+    elseif (!$this->isPatchingEnabled()) {
       return;
     }
 
@@ -353,6 +361,17 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     if (!$patched) {
       throw new \Exception("Cannot apply patch $patch_url");
     }
+  }
+
+  /**
+   * Checks if the root package enables patching.
+   *
+   * @return bool
+   *   Whether patching is enabled. Defaults to TRUE.
+   */
+  protected function isPatchingEnabled() {
+    $extra = $this->composer->getPackage()->getExtra();
+    return isset($extra['enable-patching']) ? $extra['enable-patching'] : TRUE;
   }
 
   /**

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -371,7 +371,15 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    */
   protected function isPatchingEnabled() {
     $extra = $this->composer->getPackage()->getExtra();
-    return isset($extra['enable-patching']) ? $extra['enable-patching'] : TRUE;
+
+    // If the root package has no patches of its own, patching is only enabled
+    // if specifically opted in.
+    if (empty($extra['patches'])) {
+      return $extra['enable-patching'] === TRUE;
+    }
+    else {
+      return TRUE;
+    }
   }
 
   /**

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -372,10 +372,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   protected function isPatchingEnabled() {
     $extra = $this->composer->getPackage()->getExtra();
 
-    // If the root package has no patches of its own, patching is only enabled
-    // if specifically opted in.
     if (empty($extra['patches'])) {
-      return $extra['enable-patching'] === TRUE;
+      // The root package has no patches of its own, so only allow patching if
+      // it has specifically opted in.
+      return isset($extra['enable-patching']) ? $extra['enable-patching'] : FALSE;
     }
     else {
       return TRUE;

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -135,7 +135,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     }
 
     $this->patches = $this->grabPatches();
-    if ($this->patches == FALSE) {
+    if (empty($this->patches)) {
       $this->io->write('<info>No patches supplied.</info>');
     }
 
@@ -216,7 +216,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
     }
     else {
-      return FALSE;
+      return array();
     }
   }
 


### PR DESCRIPTION
My situation is simple: I have a package that has no patches. It does, however, pull in dependencies that have patches. When I install or update, the dependencies' patches are not applied.

I traced this to gatherPatches() returning early if grabPatches() returns anything falsy. Not sure if this is by design or a bug, but it certainly stops it from working as advertised! :) This here PR should fix the problem.