### PR TITLE
Patch root packages last

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -142,10 +142,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       return;
     }
 
-    $this->patches = $this->grabPatches();
-    if (empty($this->patches)) {
-      $this->io->write('<info>No patches supplied.</info>');
-    }
+    $this->patches = [];
 
     // Now add all the patches from dependencies that will be installed.
     $operations = $event->getOperations();
@@ -158,6 +155,14 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           $this->patches = array_merge_recursive($this->patches, $extra['patches']);
         }
       }
+    }
+
+    $local_patches = $this->grabPatches();
+    if (empty($local_patches)) {
+      $this->io->write('<info>No patches supplied.</info>');
+    }
+    else {
+      $this->patches = array_merge_recursive($this->patches, $local_patches);
     }
 
     // If we're in verbose mode, list the projects we're going to patch.


### PR DESCRIPTION
I'm not sure this is a good idea, but I wanted to put it out for comment.

With enable-patches set to true, I'd expect patches to be applied recursively starting from the furthest dependency, with the root package being last. This PR simply applies root patches last, so if you need to iterate on a dependent patch you can.

Thoughts?
