### PR TITLE
Print error message when patch couldn't be applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Then your composer.patches.json should look like this:
 }
 ```
 
+## Using patches from HTTP URLs
+
+Composer [blocks](https://getcomposer.org/doc/06-config.md#secure-http) you from downloading anything from HTTP URLs, you can disable this for your project by adding a ```secure-http``` setting in the config section of your composer.json. Note that the ```config``` section should be under the root of your composer.json.
+
+```
+{
+  "config": {
+    "secure-http": false
+  }
+}
+```
+
+However, it's always advised to setup HTTPS to prevent MITM code injection.
+
 ## Difference between this and netresearch/composer-patches-plugin
 
 * This plugin is much more simple to use and maintain

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -269,7 +269,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $extra['patches_applied'][$description] = $url;
       }
       catch (\Exception $e) {
-        $this->io->write('   <error>Could not apply patch! Skipping.</error>');
+        $this->io->write('   <error>Could not apply patch! Skipping. The error was: ' . $e->getMessage() . '</error>');
         if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE')) {
           throw new \Exception("Cannot apply patch $description ($url)!");
         }


### PR DESCRIPTION
Yesterday I spent 2 hours looking for the problem.
The only message I got was: ```Could not apply patch! Skipping```
Apparently it was because Composer does not want to download patches over http (since 1.0.0).

This PR makes the error also print the the Exception message..
Old:
![image](https://cloud.githubusercontent.com/assets/1312921/15666075/022044c6-270f-11e6-914d-272d6b89f457.png)

New:
![image](https://cloud.githubusercontent.com/assets/1312921/15666069/fef46dea-270e-11e6-95d5-e769b1c2ee75.png)

