### PR TITLE
Document 'enable-patching' attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Instead of a patches key in your root composer.json, use a patches-file key.
     "preferred-install": "source"
   },
   "extra": {
+    "enable-patching": true,
     "patches-file": "local/path/to/your/composer.patches.json"
   }
 }


### PR DESCRIPTION
Patches stopped working in one of my projects a while back. It appears that now, if you want to use an external patch file, you must enable patching via the "enable-patching" attribute.

This could also be fixed by [adjusting the test for root-level patches](https://github.com/cweagans/composer-patches/blob/master/src/Patches.php#L375), if perhaps that is what was intended.
