### PR TITLE
isPatchingEnabled() checks 'patches-file' too

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -372,7 +372,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   protected function isPatchingEnabled() {
     $extra = $this->composer->getPackage()->getExtra();
 
-    if (empty($extra['patches'])) {
+    if (empty($extra['patches']) && empty($extra['patches-file'])) {
       // The root package has no patches of its own, so only allow patching if
       // it has specifically opted in.
       return isset($extra['enable-patching']) ? $extra['enable-patching'] : FALSE;


### PR DESCRIPTION
isPatchingEnabled() will also take into consideration 'patches-file' when determining if root package uses patches.

I use the patches-file setting in the composer.json file, and after upgrading to 1.5.0 my patches were not applying anymore. I followed the code to the isPatchingEnabled(), where if enable-patching is not set, it will default to true if the root package uses patches, and to false otherwise.

However, detecting if the root project uses patches was done only based on the 'patches' key.

This PR checks also if 'patches-file' exists to determine if the root project uses patches.
