### PR TITLE
Convert the path to a realpath

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -314,7 +314,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     // Local patch file.
     if (file_exists($patch_url)) {
-      $filename = $patch_url;
+      $filename = realpath($patch_url);
     }
     else {
       // Generate random (but not cryptographically so) filename.


### PR DESCRIPTION
I was not able to apply local patches so I created this fix, that transforms the relative path to a real path, to enable applying local patches.