### PR TITLE
Make local patches work with Git

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -314,7 +314,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     // Local patch file.
     if (file_exists($patch_url)) {
-      $filename = $patch_url;
+      $filename = realpath($patch_url);
     }
     else {
       // Generate random (but not cryptographically so) filename.


### PR DESCRIPTION
The Git patch command currently looks like this:

    cd path/to/package && GIT_DIR=. git apply --check -pX path/to/patch/file.patch

As we first `cd` into the package directory, Git is unable to find the patch file at `path/to/package/path/to/patch/file.patch`