### PR TITLE
Added the ability to ignore specific patches from dependencies

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -147,6 +147,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $this->io->write('<info>No patches supplied.</info>');
     }
 
+    $extra = $this->composer->getPackage()->getExtra();
+    $patches_ignore = isset($extra['patches-ignore']) ? $extra['patches-ignore'] : [];
+
     // Now add all the patches from dependencies that will be installed.
     $operations = $event->getOperations();
     $this->io->write('<info>Gathering patches for dependencies. This might take a minute.</info>');
@@ -155,6 +158,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $package = $this->getPackageFromOperation($operation);
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {
+          if (isset($patches_ignore[$package->getName()])) {
+            foreach ($patches_ignore[$package->getName()] as $package => $patches) {
+              if (isset($extra['patches'][$package])) {
+                $extra['patches'][$package] = array_diff($extra['patches'][$package], $patches);
+              }
+            }
+          }
           $this->patches = array_merge_recursive($this->patches, $extra['patches']);
         }
       }
@@ -372,7 +382,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   protected function isPatchingEnabled() {
     $extra = $this->composer->getPackage()->getExtra();
 
-    if (empty($extra['patches'])) {
+    if (empty($extra['patches']) && empty($extra['patches-ignore'])) {
       // The root package has no patches of its own, so only allow patching if
       // it has specifically opted in.
       return isset($extra['enable-patching']) ? $extra['enable-patching'] : FALSE;


### PR DESCRIPTION
This PR adds a new feature, "patches-ignore", which allows a Composer package to ignore specific patches from dependencies. There are a number of use cases for the composer-patches project that this enhances:

1. I use a different more recent version of a dependency, and now a patch isn't applying.
2. I have a more up to date patch than my dependency, and want to use mine instead of theirs.
3. A dependency's patch adds a feature to a project that I don't need.
4. My patches conflict with a dependency's patches.

This is also a critical feature for Drupal distributions that require other distributions, as distributions typically contain loads of patches for Drupal modules. For the "child" distribution, using a different version of a module means that parent patches will not apply, which could break the build or cause unintended consequences. With this feature, a child distribution could ignore a patch that applied to an older version of a dependency, use a newer version of that dependency, and add a newer patch that applies cleanly.

Here's an example composer.json I wrote which requires the Lightning distribution for Drupal, and ignores a patch which adds a feature that conflicts with an edge case in our distribution (Demo Framework). This is use case 3 mentioned above:

```
{
  "minimum-stability": "dev",
  "repositories": [
    {
      "type": "composer",
      "url": "https://packagist.drupal-composer.org"
    },
    {
      "type": "vcs",
      "url": "https://github.com/mortenson/composer-patches"
    }
  ],
  "require": {
    "drupal/lightning": "dev-8.x-1.x",
    "cweagans/composer-patches": "dev-master as 1.5.0"
  },
  "extra": {
    "patches-ignore": {
      "drupal/lightning": {
        "drupal/panelizer": {
          "This patch has known conflicts with our Quick Edit integration": "https://www.drupal.org/files/issues/2664682-49.patch"
        }
      }
    }
  }
}
```