### PR TITLE
Update README to make it obvious how dependency's patches can be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ Then your composer.patches.json should look like this:
 }
 ```
 
+## Allowing patches to be applied from dependencies
+
+If you want your project to accept patches from dependencies, you must have the following in your composer file:
+
+```
+{
+  "require": {
+      "cweagans/composer-patches": "^1.5.0"
+  },
+  "extra": {
+      "enable-patching": true
+  }
+}
+```
+
 ## Difference between this and netresearch/composer-patches-plugin
 
 * This plugin is much more simple to use and maintain


### PR DESCRIPTION
I just spent a good hour trying to figure out why this wasn't working for me and had to find [this comment](https://github.com/cweagans/composer-patches/pull/36#issuecomment-235565088) to figure out why. It clearly states in the README that this project supports applying patches from dependencies but doesn't tell you how.