### PR TITLE
Replace Composer\Script\PackageEvent with Composer\Installer\PackageEvent

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -20,7 +20,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Installer\PackageEvents;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
-use Composer\Script\PackageEvent;
+use Composer\Installer\PackageEvent;
 use Composer\Util\ProcessExecutor;
 use Composer\Util\RemoteFilesystem;
 use Symfony\Component\Process\Process;


### PR DESCRIPTION
This is a PR based off of this issue to correct the deprecation notice. Nooooo idea if this fixes it, but at least this is an attempt.

https://github.com/cweagans/composer-patches/issues/82

````
Deprecation Notice: The callback cweagans\Composer\Patches::postInstall declared at .../vendor/cweagans/composer-patches/src/Patches.php accepts a Composer\Script\PackageEvent but post-package-install events use a Composer\Installer\PackageEvent instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes in phar:///home/travis/.phpenv/versions/5.6.5/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:308
Deprecation Notice: The callback cweagans\Composer\Patches::gatherPatches declared at .../vendor/cweagans/composer-patches/src/Patches.php accepts a Composer\Script\PackageEvent but pre-package-install events use a Composer\Installer\PackageEvent instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes in phar:///home/travis/.phpenv/versions/5.6.5/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:308
````