### PR TITLE
Explicitly define the BSD license version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "cweagans/composer-patches",
   "description": "Provides a way to patch Composer packages.",
   "minimum-stability": "dev",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "type": "composer-plugin",
   "extra": {
     "class": "cweagans\\Composer\\Patches"


### PR DESCRIPTION
composer validate warning output:
```
cweagans/composer-patches is valid, but with a few warnings
License "BSD" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```

This PR picks BSD-2-Clause from https://spdx.org/licenses/ and therefore removes the warnings on composer install.