### PR TITLE
Only show debugging info when using the verbose option

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -139,12 +139,12 @@ class Patches implements PluginInterface, EventSubscriberInterface {
   public function gatherPatches(PackageEvent $event) {
     // If we've already done this, then don't do it again.
     if (isset($this->patches['_patchesGathered'])) {
-      $this->io->write('<info>Patches already gathered. Skipping</info>');
+      $this->io->write('<info>Patches already gathered. Skipping</info>', TRUE, IOInterface::VERBOSE);
       return;
     }
     // If patching has been disabled, bail out here.
     elseif (!$this->isPatchingEnabled()) {
-      $this->io->write('<info>Patching is disabled. Skipping.</info>');
+      $this->io->write('<info>Patching is disabled. Skipping.</info>', TRUE, IOInterface::VERBOSE);
       return;
     }
 


### PR DESCRIPTION
Since #77 got in there is some unneeded chatter about the patch process added to the composer output:

```
Patches already gathered. Skipping
  - Removing symfony/class-loader (v2.8.14)
  - Installing symfony/class-loader (v2.8.15)
    Loading from cache

Patches already gathered. Skipping
  - Removing symfony/http-kernel (v2.8.14)
  - Installing symfony/http-kernel (v2.8.15)
    Loading from cache

Patches already gathered. Skipping
  - Removing symfony/routing (v2.8.14)
  - Installing symfony/routing (v2.8.15)
    Loading from cache

Patches already gathered. Skipping
  - Removing symfony/serializer (v2.8.14)
  - Installing symfony/serializer (v2.8.15)
    Loading from cache

Patches already gathered. Skipping
  - Removing symfony/validator (v2.8.14)
  - Installing symfony/validator (v2.8.15)
    Loading from cache
```

This information is only useful when debugging problems. Let's hide these messages unless composer is invoked with the `-v` option.