### PR TITLE
Renamed variable, which is accidentally modified while ignoring patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -165,9 +165,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {
           if (isset($patches_ignore[$package->getName()])) {
-            foreach ($patches_ignore[$package->getName()] as $package => $patches) {
-              if (isset($extra['patches'][$package])) {
-                $extra['patches'][$package] = array_diff($extra['patches'][$package], $patches);
+            foreach ($patches_ignore[$package->getName()] as $package_name => $patches) {
+              if (isset($extra['patches'][$package_name])) {
+                $extra['patches'][$package_name] = array_diff($extra['patches'][$package_name], $patches);
               }
             }
           }


### PR DESCRIPTION
When a patch is ignored, the foreach loop uses the variable $package as the key which overrides the $package variable set earlier in the gatherPatches() function. This causes patching to fail and causes PHP errors.