### PR TITLE
Do not hide command fails.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -454,7 +454,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         }
       };
     }
-    return ($this->executor->execute($command, $output) == 0);
+    return ($this->executor->execute($command, $output) == 0) && (empty($this->executor->getErrorOutput()));
   }
 
   /**


### PR DESCRIPTION
When doing git-apply it will silently fail with stuff such as "skips" because current implementation of executeCommand() does not check error output.

Proposed fix that properly propagates the fact the the command has failed when there is something in the error output.