### PR TITLE
Improve patched check

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -351,17 +351,21 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $downloader->copy($hostname, $patch_url, $filename, FALSE);
     }
 
-    // The order here is intentional. p1 is most likely to apply with git apply.
-    // p0 is next likely. p2 is extremely unlikely, but for some special cases,
-    // it might be useful.
-    $patch_levels = array('-p1', '-p0', '-p2');
-    foreach ($patch_levels as $patch_level) {
-      $patched = $this->executeCommand('cd %s && git --git-dir=. apply -R --check %s %s', $install_path, $patch_level, $filename);
-      $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
-      if ($checked && !$patched) {
-        // Apply the first successful style.
-        $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
-        break;
+    // Check if code is patched already.
+    $patched = $this->executeCommand('cd %s && git --git-dir=. apply -R --check -p1 %s', $install_path, $filename);
+
+    if (!$patched) {
+      // The order here is intentional. p1 is most likely to apply with git apply.
+      // p0 is next likely. p2 is extremely unlikely, but for some special cases,
+      // it might be useful.
+      $patch_levels = array('-p1', '-p0', '-p2');
+      foreach ($patch_levels as $patch_level) {
+        $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
+        if ($checked) {
+          // Apply the first successful style.
+          $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
+          break;
+        }
       }
     }
 

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -351,15 +351,14 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $downloader->copy($hostname, $patch_url, $filename, FALSE);
     }
 
-    // Modified from drush6:make.project.inc
-    $patched = FALSE;
     // The order here is intentional. p1 is most likely to apply with git apply.
     // p0 is next likely. p2 is extremely unlikely, but for some special cases,
     // it might be useful.
     $patch_levels = array('-p1', '-p0', '-p2');
     foreach ($patch_levels as $patch_level) {
+      $patched = $this->executeCommand('cd %s && git --git-dir=. apply -R --check %s %s', $install_path, $patch_level, $filename);
       $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
-      if ($checked) {
+      if ($checked && !$patched) {
         // Apply the first successful style.
         $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
         break;


### PR DESCRIPTION
To provide compatibility with https://github.com/Letudiant/composer-shared-package-plugin we should add a check to see if the patch was already applied. Currently if there is a shared package it will create the symlink and try to re-apply the patch. If we first check if the patch was already applied then we will not get a false positive on patch failiure.