### PR TITLE
Fix detect dependency patch changes

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -133,13 +133,15 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           }
         }
 
-        // If we're in verbose mode, list the projects we're going to patch
-        // and the possible patches that are ignored.
-        if ($this->io->isVerbose()) {
-          if (!empty($ignored_patches)) {
-            $this->io->write('<info>Ignore ' . $package_name . ' patches: ' . implode(', ', $ignored_patches) . '</info>');
-          }
+        // If we're in verbose mode, list the patches that are ignored.
+        if ($this->io->isVerbose() && !empty($ignored_patches)) {
+          $this->io->write('<info>Ignore ' . $package_name . ' patches: ' . implode(', ', $ignored_patches) . '</info>');
+        }
+      }
 
+      // If we're in verbose mode, list all found patches per package.
+      if ($this->io->isVerbose()) {
+        foreach ($all_patches as $package_name => $patches) {
           $number = count($all_patches[$package_name]);
           $this->io->write('<info>Found ' . $number . ' patches for ' . $package_name . '.</info>');
         }
@@ -215,9 +217,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           default:
             $msg =  ' - Unknown error';
             break;
-          }
-          throw new \Exception('There was an error in the supplied patches file:' . $msg);
         }
+        throw new \Exception('There was an error in the supplied patches file:' . $msg);
+      }
       if (isset($patches['patches'])) {
         $patches = $patches['patches'];
         return $patches;

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -339,10 +339,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // it might be useful.
     $patch_levels = array('-p1', '-p0', '-p2');
     foreach ($patch_levels as $patch_level) {
-      $checked = $this->executeCommand('cd %s && git apply --check %s %s', $install_path, $patch_level, $filename);
+      $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
       if ($checked) {
         // Apply the first successful style.
-        $patched = $this->executeCommand('cd %s && git apply %s %s', $install_path, $patch_level, $filename);
+        $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
         break;
       }
     }

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -103,7 +103,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
       $all_patches = $root_patches;
 
-      $this->io->write('<info>Gathering patches defined by dependecy packages.</info>');
+      $this->io->write('<info>Gathering patches defined by dependency packages.</info>');
 
       foreach ($packages as $package) {
         $extra = $package->getExtra();


### PR DESCRIPTION
Changes in patch definitions of dependency patches are currently only picked up after a second install or update.

This approach building on fixes of #118 tries to remedy this.

The catch is that we only know after installing/updating dependencies if their composer.lock has been changed. So we need some action in post install/updates.