### PR TITLE
Extra check for uninstallation

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -431,7 +431,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    *
    * @param string $directory
    */
-  function checkPatchReport($directory) {
+  protected function checkPatchReport($directory) {
     return file_exists(sprintf('%s/PATCHES.txt', $directory));
   }
 

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -114,8 +114,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           $extra = $package->getExtra();
           $has_patches = isset($tmp_patches[$package_name]);
           $has_applied_patches = isset($extra['patches_applied']);
+          $patch_report_exists = $this->checkPatchReport($installationManager->getInstaller($package->getType())->getInstallPath($package));
           if (($has_patches && !$has_applied_patches)
             || (!$has_patches && $has_applied_patches)
+            || ($has_patches && $has_applied_patches && !$patch_report_exists)
             || ($has_patches && $has_applied_patches && $tmp_patches[$package_name] !== $extra['patches_applied'])) {
             $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
             $this->io->write('<info>Removing package ' . $package_name . ' so that it can be re-installed and re-patched.</info>');
@@ -422,6 +424,15 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $output .= 'Source: ' . $url . "\n\n\n";
     }
     file_put_contents($directory . "/PATCHES.txt", $output);
+  }
+
+  /**
+   * Check if a patch report exists in the target directory.
+   *
+   * @param string $directory
+   */
+  function checkPatchReport($directory) {
+    return file_exists(sprintf('%s/PATCHES.txt', $directory));
   }
 
   /**


### PR DESCRIPTION
We stumbled upon an issue whereby running `composer install --no-scripts` before the regular `composer install` no patches were getting applied. This all due to our deploy strategy with a buid- and deploy-server. 
This makes absolute sense because Patches listens to the install event of a package, which does not occur the second time and is prohibited the first time. Therefor I added an extra check during the checkPatches-function which will search for the patch report. If that does not exists but there are patches available and those are applied (according to composer.lock), then re-install the dependency.