### PR TITLE
optionally prefer patch util over git apply

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -355,9 +355,8 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $patched = FALSE;
     // The order here is intentional. p1 is most likely to apply with git apply.
     // p0 is next likely. p2 is extremely unlikely, but for some special cases,
-    // it might be useful. But if the drupal core is installed in a subfolder
-    // p2 is the most likely.
-    $patch_levels = preg_match('@^[^/\.]+/core$@', trim($install_path, "'")) ? array('-p2', '-p1', '-p0') : array('-p1', '-p0', '-p2');
+    // it might be useful.
+    $patch_levels = array('-p1', '-p0', '-p2');
     foreach ($patch_levels as $patch_level) {
       $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
       if ($checked) {

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -355,8 +355,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $patched = FALSE;
     // The order here is intentional. p1 is most likely to apply with git apply.
     // p0 is next likely. p2 is extremely unlikely, but for some special cases,
-    // it might be useful.
-    $patch_levels = array('-p1', '-p0', '-p2');
+    // it might be useful. But if the drupal core is installed in a subfolder
+    // p2 is the most likely.
+    $patch_levels = preg_match('@^[^/\.]+/core$@', trim($install_path, "'")) ? array('-p2', '-p1', '-p0') : array('-p1', '-p0', '-p2');
     foreach ($patch_levels as $patch_level) {
       $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
       if ($checked) {

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -358,18 +358,31 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // it might be useful. But if the drupal core is installed in a subfolder
     // p2 is the most likely.
     $patch_levels = preg_match('@^[^/\.]+/core$@', trim($install_path, "'")) ? array('-p2', '-p1', '-p0') : array('-p1', '-p0', '-p2');
-    foreach ($patch_levels as $patch_level) {
-      $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
-      if ($checked) {
-        // Apply the first successful style.
-        $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
-        break;
+
+    if ($this->isPatchUtilityPreferred()) {
+      foreach ($patch_levels as $patch_level) {
+        // --no-backup-if-mismatch here is a hack that fixes some
+        // differences between how patch works on windows and unix.
+        if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+          break;
+        }
+      }
+    }
+
+    if (!$patched) {
+      foreach ($patch_levels as $patch_level) {
+        $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
+        if ($checked) {
+          // Apply the first successful style.
+          $patched = $this->executeCommand('cd %s && git --git-dir=. apply %s %s', $install_path, $patch_level, $filename);
+          break;
+        }
       }
     }
 
     // In some rare cases, git will fail to apply a patch, fallback to using
     // the 'patch' command.
-    if (!$patched) {
+    if (!$patched && !$this->isPatchUtilityPreferred()) {
       foreach ($patch_levels as $patch_level) {
         // --no-backup-if-mismatch here is a hack that fixes some
         // differences between how patch works on windows and unix.
@@ -407,6 +420,18 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     else {
       return TRUE;
     }
+  }
+
+  /**
+   * Checks if the root package enables patching.
+   *
+   * @return bool
+   *   Whether the patch utility is preferred over git apply. Defaults to FALSE
+   */
+  protected function isPatchUtilityPreferred() {
+    $extra = $this->composer->getPackage()->getExtra();
+
+    return isset($extra['prefer-patch-util']) ? $extra['prefer-patch-util'] : FALSE;
   }
 
   /**


### PR DESCRIPTION
In our projects in happens very often that git apply doesn't succeed but the patch utility fallback does.
This PR introduces an prefer-patch-util option for the extras section. If set to true, the patch util is tried before git apply.