### PR TITLE
Add switch to $patch_levels for Magento 2 Official Patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -355,8 +355,8 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $patched = FALSE;
     // The order here is intentional. p1 is most likely to apply with git apply.
     // p0 is next likely. p2 is extremely unlikely, but for some special cases,
-    // it might be useful.
-    $patch_levels = array('-p1', '-p0', '-p2');
+    // it might be useful. p4 is useful for Magento 2 patches
+    $patch_levels = array('-p1', '-p0', '-p2', '-p4');
     foreach ($patch_levels as $patch_level) {
       $checked = $this->executeCommand('cd %s && git --git-dir=. apply --check %s %s', $install_path, $patch_level, $filename);
       if ($checked) {


### PR DESCRIPTION
Magento is a fairly popular software where composer-patches is especially useful.  Patch files distributed by Magento in some special cases are based in the root directory, containing paths like `a/vendor/magento/module-catalog`.  In cases such as these, if only a single module is referenced in the patch file then a -p4 flag will allow the patch to work as distributed by Magento.