### PR TITLE
Fix problem with array_merge_recursive.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -104,7 +104,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
           $this->installedPatches[$package->getName()] = $extra['patches'];
         }
         $patches = isset($extra['patches']) ? $extra['patches'] : array();
-        $tmp_patches = array_merge_recursive($tmp_patches, $patches);
+
+        // Ensure that duplicate patches are overwritten not merged.
+        foreach ($patches as $package_name => $values) {
+          foreach ($values as $description => $patchfile) {
+            $tmp_patches[$package_name][$description] = $patchfile;
+          }
+        }
       }
 
       // Remove packages for which the patch set has changed.


### PR DESCRIPTION
array_merge_recursive sometimes finds duplicate patches and then ends up with the patch files being an array of URLs instead of just the URL / path to the patchfile itself.

This would need drupal_array_merge_deep(), but as that is not available a double for-loop also solves the problem.

It is also more explicit about the data structure expected.