### PR TITLE
Fix duplicate entries after failed patch.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -295,7 +295,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
       catch (\Exception $e) {
         $this->io->write('   <error>Could not apply patch! Skipping. The error was: ' . $e->getMessage() . '</error>');
-        $extra = $this->composer->getPackage()->getExtra();
         if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') || !empty($extra['composer-exit-on-patch-failure'])) {
           throw new \Exception("Cannot apply patch $description ($url)!");
         }


### PR DESCRIPTION
This supersedes #142, though installed.json needs to be manually cleaned to get back to a good state.

Closes: #123