### PR TITLE
Multiple packages use the same patch throw an array to string exception

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -182,7 +182,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     // Merge installed patches from dependencies that did not receive an update.
     foreach ($this->installedPatches as $patches) {
-      $this->patches = array_merge_recursive($this->patches, $patches);
+      $this->patches = $this->arrayMergeRecursiveDistinct($this->patches, $patches);
     }
 
     // If we're in verbose mode, list the projects we're going to patch.


### PR DESCRIPTION
Try to complete fix from https://github.com/cweagans/composer-patches/issues/38 when patchs are already installed