### PR TITLE
Don't return too early before gathering patches of dependencies

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -93,11 +93,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $packages = $localRepository->getPackages();
 
       $tmp_patches = $this->grabPatches();
-      if ($tmp_patches == FALSE) {
-        $this->io->write('<info>No patches supplied.</info>');
-        return;
-      }
-
       foreach ($packages as $package) {
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {
@@ -105,6 +100,11 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         }
         $patches = isset($extra['patches']) ? $extra['patches'] : array();
         $tmp_patches = array_merge_recursive($tmp_patches, $patches);
+      }
+
+      if ($tmp_patches == FALSE) {
+        $this->io->write('<info>No patches supplied.</info>');
+        return;
       }
 
       // Remove packages for which the patch set has changed.


### PR DESCRIPTION
Without this patch, the plugin would already return if there are no patches in the root composer.json. Even with `enable-patching` the early return does not allow to gather patches from dependencies.

Since this is a relative small bugfix, would be cool if you find time to merge that as fast as you can :smirk:  As we want to roll out the patches on a larger project base (>20 projects and counting) :heart: :heart: 