### PR TITLE
Increase post install/update handler priority to support other plugins

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -68,12 +68,12 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return array(
-      ScriptEvents::PRE_INSTALL_CMD => "checkPatches",
-      ScriptEvents::PRE_UPDATE_CMD => "checkPatches",
-      PackageEvents::PRE_PACKAGE_INSTALL => "gatherPatches",
-      PackageEvents::PRE_PACKAGE_UPDATE => "gatherPatches",
-      PackageEvents::POST_PACKAGE_INSTALL => "postInstall",
-      PackageEvents::POST_PACKAGE_UPDATE => "postInstall",
+      ScriptEvents::PRE_INSTALL_CMD => array('checkPatches'),
+      ScriptEvents::PRE_UPDATE_CMD => array('checkPatches'),
+      PackageEvents::PRE_PACKAGE_INSTALL => array('gatherPatches'),
+      PackageEvents::PRE_PACKAGE_UPDATE => array('gatherPatches'),
+      PackageEvents::POST_PACKAGE_INSTALL => array('postInstall', 10),
+      PackageEvents::POST_PACKAGE_UPDATE => array('postInstall', 10),
     );
   }
 

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -72,6 +72,12 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       ScriptEvents::PRE_UPDATE_CMD => array('checkPatches'),
       PackageEvents::PRE_PACKAGE_INSTALL => array('gatherPatches'),
       PackageEvents::PRE_PACKAGE_UPDATE => array('gatherPatches'),
+      // The following is a higher weight for compatibility with
+      // https://github.com/AydinHassan/magento-core-composer-installer and more generally for compatibility with
+      // every Composer plugin which deploys downloaded packages to other locations.
+      // In such cases you want that those plugins deploy patched files so they have to run after
+      // the "composer-patches" plugin.
+      // @see: https://github.com/cweagans/composer-patches/pull/153
       PackageEvents::POST_PACKAGE_INSTALL => array('postInstall', 10),
       PackageEvents::POST_PACKAGE_UPDATE => array('postInstall', 10),
     );


### PR DESCRIPTION
There are many other Composer's plugins that perform install operation on packages after they have been installed. Many times this operation involves coping packages files elsewhere (look at https://github.com/AydinHassan/magento-core-composer-installer for an example). In such situation it's useful to have patches applied BEFORE the install/copy operation. So, this PR increase the post install/update event handler's priority so other plugins (with priority=0) to run after that patches have been applied.