### PR TITLE
Correctly resolve relative local paths pointing to patch files from dependencies

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -102,6 +102,16 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       foreach ($packages as $package) {
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {
+          // Go through each of this package's defined patches and make sure paths to patches
+          // defined relative to their home package are resolved properly.
+          $packageDir = $installationManager->getInstallPath($package);
+          foreach ($extra['patches'] as &$singlePackage) {
+            foreach ($singlePackage as &$path) {
+              if (realpath($tmp = "$packageDir/$path")) {
+                $path = $tmp;
+              }
+            }
+          }
           $this->installedPatches[$package->getName()] = $extra['patches'];
         }
         $patches = isset($extra['patches']) ? $extra['patches'] : array();


### PR DESCRIPTION
This ***may be quite naive solution*** and may need some more work *(it may  break something else elsewhere)*, but this already solved my problem where - *having this multi-project structure* - ...

```
- MY_PROJECT_1
  - Requires: MY_PROJECT_2
  - Extra:
    {
      "enable-patching": true,
      "patches": {}
    },
- MY_PROJECT_2
  - Requires: 3RD_PARTY_PROJECT
  - Extra:
    {
      "patches": {
        "3RD_PARTY_PROJECT": {
          "Important patch": "./patches/an_important.patch" // Path relative to MY_PROJECT_2's root.
        }
    }
  
```

... the `./patches/an_important.patch` specified relatively to *MY_PROJECT_2*'s path ***wouldn't be properly resolved*** when running `composer install/update` inside the *MY_PROJECT_1*'s root directory.

> The "./patches/an_important.patch" file could not be downloaded: failed to open stream: No such file or directory

It seems to be solved by first trying whether the `dependency's root path` + `relatively specified path to dependency's patch` does - by any chance - actually represent an existing path.

If it does, that new absolute path is used instead. This IMO should handle most of the cases where the path to the patch file is specified some other way - an *URL*, some *absolute path* or *deliberately specified relative path*. In these cases `realpath()` should return false and originally specified path should be used.

*Any thoughts?*

---

Also, may be related to https://github.com/cweagans/composer-patches/issues/146.