### PR TITLE
Exit on patch failure should use composer extra, not localPackage

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -275,6 +275,10 @@ class Patches implements PluginInterface, EventSubscriberInterface
      */
     public function postInstall(PackageEvent $event)
     {
+        // Check if we should exit in failure.
+        $extra = $this->composer->getPackage()->getExtra();
+        $exitOnFailure = getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') || !empty($extra['composer-exit-on-patch-failure']);
+
         // Get the package object for the current operation.
         $operation = $event->getOperation();
         /** @var PackageInterface $package */
@@ -321,7 +325,7 @@ class Patches implements PluginInterface, EventSubscriberInterface
                     $e->getMessage() .
                     '</error>'
                 );
-                if (getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') || !empty($extra['composer-exit-on-patch-failure'])) {
+                if ($exitOnFailure) {
                     throw new \Exception("Cannot apply patch $description ($url)!");
                 }
             }


### PR DESCRIPTION
Under error handling, two mechanisms are given for halting on patch failure: setting an environment variable and adding an option to the extra section of composer.json. But only the first works - the composer.json setting does not work, or at least does not work as described.

It seems that the code is looking for the extra setting in $localPackage->getExtra() whereas I think it should be looking in the root composer.json $this->composer->getPackage()->getExtra().

This pull request changes the behavior to look only at the root. I am making the assumption that the root should take precedence over localPackage -- once could argue, I guess, that both should be consulted but since one major purpose of this setting is continuous integration, I think it probably expected that the root composer.json is the one that controls CI work flow and should be preferred.