### PR TITLE
Fixes #168: skip duplicate patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -307,7 +307,7 @@ class Patches implements PluginInterface, EventSubscriberInterface
         $extra['patches_applied'] = array();
 
         foreach ($this->patches[$package_name] as $description => $url) {
-            if (in_array($extra['patches_applied'], $url, true)) {
+            if (in_array($url, $extra['patches_applied'], true)) {
                 continue;
             }
             $this->io->write('    <info>' . $url . '</info> (<comment>' . $description . '</comment>)');

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -307,6 +307,9 @@ class Patches implements PluginInterface, EventSubscriberInterface
         $extra['patches_applied'] = array();
 
         foreach ($this->patches[$package_name] as $description => $url) {
+            if (in_array($extra['patches_applied'], $url, true)) {
+                continue;
+            }
             $this->io->write('    <info>' . $url . '</info> (<comment>' . $description . '</comment>)');
             try {
                 $this->eventDispatcher->dispatch(


### PR DESCRIPTION
When the same patch is called in twice, it will generate a conflict on the second apply.

> $ composer update
> Gathering patches for root package.
> Removing package drupal/coder so that it can be re-installed and re-patched.
>   - Removing drupal/coder (8.2.12)
> Loading composer repositories with package information
> Updating dependencies (including require-dev)                              
> Package operations: 1 install, 0 updates, 0 removals
> Gathering patches for root package.
> Gathering patches for dependencies. This might take a minute.
>  - Installing drupal/coder (8.2.12): Cloning 984c54a7b1 from cache
>  - Applying patches for drupal/coder
>    https://www.drupal.org/files/issues/2804739-7.patch (Allow underscore properties in Annotation classes)
>    https://www.drupal.org/files/issues/2804739-7.patch (Allow underscore properties in Annotation class)
>   Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/2804739-7.patch

You can see the effect if you add a patch to a composer.json file twice. Of course, you can say that is just a typo. The problem really is the case where two child packages bring in the same patch -- if the system collects patches from lower-level composer.json files, the particular patches that are applied are much harder to control over time.

This patch simply skips patches with the same URL on the second attempt to apply them. It should be possible to accomplish the same effect when gathering patches, but that only occurred to me later and I was not able to see as simple a fix there. Perhaps arrayMergeRecursiveDistinct() needs to consider value instead of or as well as key -- but I was not entirely sure about that operation so I opted for this strategy.