### PR TITLE
Fixes #174: Compatibility with older Git versions.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -363,28 +363,33 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     // Modified from drush6:make.project.inc
     $patched = FALSE;
-    // The order here is intentional. p1 is most likely to apply with git apply.
-    // p0 is next likely. p2 is extremely unlikely, but for some special cases,
-    // it might be useful. p4 is useful for Magento 2 patches
-    $patch_levels = array('-p1', '-p0', '-p2', '-p4');
-    foreach ($patch_levels as $patch_level) {
-      if ($this->io->isVerbose()) {
-        $comment = 'Testing ability to patch with git apply.';
-        $comment .= ' This command may produce errors that can be safely ignored.';
-        $this->io->write('<comment>' . $comment . '</comment>');
-      }
-      $checked = $this->executeCommand('git -C %s apply --check -v %s %s', $install_path, $patch_level, $filename);
-      $output = $this->executor->getErrorOutput();
-      if (substr($output, 0, 7) == 'Skipped') {
-        // Git will indicate success but silently skip patches in some scenarios.
-        //
-        // @see https://github.com/cweagans/composer-patches/pull/165
-        $checked = false;
-      }
-      if ($checked) {
-        // Apply the first successful style.
-        $patched = $this->executeCommand('git -C %s apply %s %s', $install_path, $patch_level, $filename);
-        break;
+
+    // Do not use git apply unless the install path is itself a git repo
+    // @see https://stackoverflow.com/a/27283285
+    if (is_dir($install_path . '/.git')) {
+      // The order here is intentional. p1 is most likely to apply with git apply.
+      // p0 is next likely. p2 is extremely unlikely, but for some special cases,
+      // it might be useful. p4 is useful for Magento 2 patches
+      $patch_levels = array('-p1', '-p0', '-p2', '-p4');
+      foreach ($patch_levels as $patch_level) {
+        if ($this->io->isVerbose()) {
+          $comment = 'Testing ability to patch with git apply.';
+          $comment .= ' This command may produce errors that can be safely ignored.';
+          $this->io->write('<comment>' . $comment . '</comment>');
+        }
+        $checked = $this->executeCommand('git -C %s apply --check -v %s %s', $install_path, $patch_level, $filename);
+        $output = $this->executor->getErrorOutput();
+        if (substr($output, 0, 7) == 'Skipped') {
+          // Git will indicate success but silently skip patches in some scenarios.
+          //
+          // @see https://github.com/cweagans/composer-patches/pull/165
+          $checked = FALSE;
+        }
+        if ($checked) {
+          // Apply the first successful style.
+          $patched = $this->executeCommand('git -C %s apply %s %s', $install_path, $patch_level, $filename);
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
I'm still testing this locally but wanted to get this out so we could start review.

The first commit is the only functional change: adding a conditional to only use `git apply` on git repos.

The second commit is a refactor to encapsulate this functionality and make it a little cleaner to edit in the future.