### PR TITLE
Fix a Unix breaking bug caused by a hack

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -420,16 +420,11 @@ class Patches implements PluginInterface, EventSubscriberInterface
         // the 'patch' command.
         if (!$patched) {
             foreach ($patch_levels as $patch_level) {
-                // --no-backup-if-mismatch here is a parameter that fixes some
-                // differences between how patch works on windows and unix.
-                // This can break other patch commands so it is only applied on Windows.
-                $patch_command = "patch %s -d %s < %s";
-                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-                    $patch_command = "patch %s --no-backup-if-mismatch -d %s < %s";
-                }
+                // --posix is added to patch in order to make sure 
+                // patch behaves the same way on windows, linux and unix
 
                 if ($patched = $this->executeCommand(
-                    $patch_command,
+                    "patch %s --posix -d %s < %s",
                     $patch_level,
                     $install_path,
                     $filename

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -420,8 +420,8 @@ class Patches implements PluginInterface, EventSubscriberInterface
         // the 'patch' command.
         if (!$patched) {
             foreach ($patch_levels as $patch_level) {
-                // --posix is added to patch in order to make sure 
-                // patch behaves the same way on windows, linux and unix
+                // --posix is added to patch in order to make sure
+                // patch behaves the same way on windows, linux and unix.
 
                 if ($patched = $this->executeCommand(
                     "patch %s --posix -d %s < %s",

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -420,10 +420,16 @@ class Patches implements PluginInterface, EventSubscriberInterface
         // the 'patch' command.
         if (!$patched) {
             foreach ($patch_levels as $patch_level) {
-                // --no-backup-if-mismatch here is a hack that fixes some
+                // --no-backup-if-mismatch here is a parameter that fixes some
                 // differences between how patch works on windows and unix.
+                // This can break other patch commands so it is only applied on Windows.
+                $patch_command = "patch %s -d %s < %s";
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                    $patch_command = "patch %s --no-backup-if-mismatch -d %s < %s";
+                }
+
                 if ($patched = $this->executeCommand(
-                    "patch %s --no-backup-if-mismatch -d %s < %s",
+                    $patch_command,
                     $patch_level,
                     $install_path,
                     $filename


### PR DESCRIPTION
~~This first checks if you are running windows before changing the patch command to a flag not supported on FreeBSD.~~
Patch is given the --posix flag now.

Should be a fix for #182 
If someone with access to multiple windows machines can test this a bit more thoroughly, would be appreciated!
