### PR TITLE
1.x Backport: Change patch behaviour to be posix instead of a flag that breaks unix

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -373,9 +373,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // the 'patch' command.
     if (!$patched) {
       foreach ($patch_levels as $patch_level) {
-        // --no-backup-if-mismatch here is a hack that fixes some
-        // differences between how patch works on windows and unix.
-        if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+        // --posix is added to patch in order to make sure
+        // patch behaves the same way on windows, linux and unix.
+        if ($patched = $this->executeCommand("patch %s --posix -d %s < %s", $patch_level, $install_path, $filename)) {
           break;
         }
       }


### PR DESCRIPTION
Same one as #184 but for the 1.x branch