### PR TITLE
FIxes #191: Still array to string exception on multiple patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -200,7 +200,7 @@ class Patches implements PluginInterface, EventSubscriberInterface
 
         // Merge installed patches from dependencies that did not receive an update.
         foreach ($this->installedPatches as $patches) {
-            $this->patches = array_merge_recursive($this->patches, $patches);
+            $this->patches = $this->arrayMergeRecursiveDistinct($this->patches, $patches);
         }
 
         // If we're in verbose mode, list the projects we're going to patch.

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -109,7 +109,7 @@ class Patches implements PluginInterface, EventSubscriberInterface
                     $this->installedPatches[$package->getName()] = $extra['patches'];
                 }
                 $patches = isset($extra['patches']) ? $extra['patches'] : array();
-                $tmp_patches = array_merge_recursive($tmp_patches, $patches);
+                $tmp_patches = $this->arrayMergeRecursiveDistinct($tmp_patches, $patches);
             }
 
             if ($tmp_patches == false) {


### PR DESCRIPTION
Fixes #191: Replace 2 more array_merge_recursive with our arrayMergeRecursiveDistinct().