### PR TITLE
Fixed incorrect path issue with relative paths when applied from dependencies

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -100,6 +100,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       $packages = $localRepository->getPackages();
 
       $tmp_patches = $this->grabPatches();
+      $fs = new Filesystem();
       foreach ($packages as $package) {
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {
@@ -107,7 +108,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
             foreach ($project as $description => &$location) {
               if (parse_url($location, PHP_URL_SCHEME) === null) {
                 // no protocol so we assume the file is local (we ignore explicit "file:" definitions)
-                $fs = new Filesystem();
                 if ($fs->isAbsolutePath($location)) {
                   $location = realpath($location);
                 } else {


### PR DESCRIPTION
When applying patches from dependencies the relative paths are used from the root of the project. These  would of course need to be relative to the dependency's path (ie. ./vendor/author/project). To fix this I have added some checks to discover if the path is relative and if so turn the path into a absolute path to prevent any path mistakes regardless of current directory.