### PR TITLE
Prevent interactive mode using the --batch flag

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -423,7 +423,7 @@ class Patches implements PluginInterface, EventSubscriberInterface
                 // --no-backup-if-mismatch here is a hack that fixes some
                 // differences between how patch works on windows and unix.
                 if ($patched = $this->executeCommand(
-                    "patch %s --no-backup-if-mismatch -d %s < %s",
+                    "patch %s --posix --batch -d %s < %s",
                     $patch_level,
                     $install_path,
                     $filename

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -420,8 +420,8 @@ class Patches implements PluginInterface, EventSubscriberInterface
         // the 'patch' command.
         if (!$patched) {
             foreach ($patch_levels as $patch_level) {
-                // --no-backup-if-mismatch here is a hack that fixes some
-                // differences between how patch works on windows and unix.
+                // --posix is added to patch in order to make sure
+                // patch behaves the same way on windows, linux and unix.
                 if ($patched = $this->executeCommand(
                     "patch %s --posix --batch -d %s < %s",
                     $patch_level,


### PR DESCRIPTION
We sometimes encounter patches that need to be applied on different directory levels, e.g. -p0, -p1, -p2, ...

The patch command however sometimes breaks on a certain level, unable to find the file and switching to interactive mode, asking the user to enter the correct path. This breaks our continuous deployment system.

The patch command has the -t | --batch flag in order to prevent the interactive mode.

I also need to apply the patch found in https://github.com/cweagans/composer-patches/issues/182 to be compatible with our FreeBSD systems.