### PR TITLE
Fixes #178: Use dry-run to test patch to avoid leftover files/folders.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -373,10 +373,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // the 'patch' command.
     if (!$patched) {
       foreach ($patch_levels as $patch_level) {
-        // --no-backup-if-mismatch here is a hack that fixes some
-        // differences between how patch works on windows and unix.
-        if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
-          break;
+        // Check whether the patch applies in its entirety, to avoid leftovers in case of partial success.
+        if ($this->executeCommand("patch --dry-run %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+          // --no-backup-if-mismatch here is a hack that fixes some
+          // differences between how patch works on windows and unix.
+          if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/cweagans/composer-patches/issues/178 for branch 1.x.