### PR TITLE
Add a fix for lightning profile (and other profiles with alternative docroots)

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -297,6 +297,18 @@ class Patches implements PluginInterface, EventSubscriberInterface
         $manager = $event->getComposer()->getInstallationManager();
         $install_path = $manager->getInstaller($package->getType())->getInstallPath($package);
 
+		if ($package_name == 'drupal/core' && $install_path == 'docroot/core') {
+	      $install_path = 'docroot';
+	      if ($this->io->isVerbose()) {
+	        $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+	      }
+	    } else if ($package_name == 'drupal/core' && $install_path == 'html/core') {
+	      $install_path = 'html';
+	      if ($this->io->isVerbose()) {
+	        $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+	      }
+	    }
+
         // Set up a downloader.
         $downloader = new RemoteFilesystem($this->io, $this->composer->getConfig());
 

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -297,17 +297,17 @@ class Patches implements PluginInterface, EventSubscriberInterface
         $manager = $event->getComposer()->getInstallationManager();
         $install_path = $manager->getInstaller($package->getType())->getInstallPath($package);
 
-		if ($package_name == 'drupal/core' && $install_path == 'docroot/core') {
-	      $install_path = 'docroot';
-	      if ($this->io->isVerbose()) {
-	        $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
-	      }
-	    } else if ($package_name == 'drupal/core' && $install_path == 'html/core') {
-	      $install_path = 'html';
-	      if ($this->io->isVerbose()) {
-	        $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
-	      }
-	    }
+        if ($package_name == 'drupal/core' && $install_path == 'docroot/core') {
+            $install_path = 'docroot';
+            if ($this->io->isVerbose()) {
+                $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+            }
+        } elseif ($package_name == 'drupal/core' && $install_path == 'html/core') {
+            $install_path = 'html';
+            if ($this->io->isVerbose()) {
+                $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+            }
+        }
 
         // Set up a downloader.
         $downloader = new RemoteFilesystem($this->io, $this->composer->getConfig());

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -300,12 +300,20 @@ class Patches implements PluginInterface, EventSubscriberInterface
         if ($package_name == 'drupal/core' && $install_path == 'docroot/core') {
             $install_path = 'docroot';
             if ($this->io->isVerbose()) {
-                $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+                $this->io->write(sprintf(
+                    "'%s [id: %s]' installation path has been altered for patching.",
+                    $package->getName(),
+                    $package->getId()
+                ));
             }
         } elseif ($package_name == 'drupal/core' && $install_path == 'html/core') {
             $install_path = 'html';
             if ($this->io->isVerbose()) {
-                $this->io->write(sprintf("'%s [id: %s]' installation path has been altered for patching.", $package->getName(), $package->getId()));
+                $this->io->write(sprintf(
+                    "'%s [id: %s]' installation path has been altered for patching.",
+                    $package->getName(),
+                    $package->getId()
+                ));
             }
         }
 


### PR DESCRIPTION
The lightning profile uses the docroot folder. Composer patches can't work with this (with Drupal core).

This adds support for the lightning profile and possibly more.