### PR TITLE
Add a patch value object + support a more verbose patch format

### DIFF
--- a/src/Patch.php
+++ b/src/Patch.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace cweagans\Composer;
+
+class Patch
+{
+    /**
+     * The package that the patch belongs to.
+     *
+     * @var string $package
+     */
+    public $package;
+
+    /**
+     * The description of what the patch does.
+     *
+     * @var string $description
+     */
+    public $description;
+
+    /**
+     * The URL where the patch is stored. Can be local.
+     *
+     * @var string $url
+     */
+    public $url;
+
+    /**
+     * The sha1 hash of the patch file.
+     *
+     * @var string $sha1
+     */
+    public $sha1;
+
+    /**
+     * The patch depth to use when applying the patch (-p flag for `patch`)
+     *
+     * @var int $depth
+     */
+    public $depth;
+}

--- a/tests/acceptance/ExpandedDefinitionRequiredOnlyCept.php
+++ b/tests/acceptance/ExpandedDefinitionRequiredOnlyCept.php
@@ -1,0 +1,6 @@
+<?php
+$I = new AcceptanceTester($scenario);
+$I->wantTo('apply a patch to a package using the expanded definition format (required props only');
+$I->amInPath(realpath(__DIR__ . '/fixtures/expanded-definition-required-only'));
+$I->runShellCommand('composer install');
+$I->canSeeFileFound('./vendor/drupal/drupal/.ht.router.php');

--- a/tests/acceptance/fixtures/expanded-definition-required-only/composer.json
+++ b/tests/acceptance/fixtures/expanded-definition-required-only/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "cweagans/composer-patches-test-project",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-2-Clause",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../composer-patches"
+    }
+  ],
+  "require": {
+    "cweagans/composer-patches": "*@dev",
+    "drupal/drupal": "~8.2"
+  },
+  "extra": {
+    "patches": {
+      "drupal/drupal": [
+        {
+          "description": "Add a startup config for the PHP web server",
+          "url": "https://www.drupal.org/files/issues/add_a_startup-1543858-58.patch"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is in preparation for being able to specify more patch properties in your patch definitions, such as sha1 hash, patch depth, and maybe more eventually.

Now that we have a value object, the next step is to break out the process of resolving patches out of the main plugin.