### PR TITLE
Document minimum git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Simple patches plugin for Composer. Applies a patch from a local or remote file 
 
 ## Support notes
 
+* Git >= 2.15.1 is required to properly apply patches.
 * If you need PHP 5.3, 5.4, or 5.5 support, you should probably use a 1.x release.
 * 1.x is mostly unsupported, but bugfixes and security fixes will still be accepted.
   1.7.0 will be the last minor release in the 1.x series.


### PR DESCRIPTION
I was building on a server with Ubuntu 16.04 and it ships with git 1.9.1. In those cases, applying patches to non-git dependencies silently fails as no error message or exit code is returned by `git apply`.

This PR just updates the README; IMO it's probably too much complexity to parse `git --version` given the format of the string isn't stable.