### PR TITLE
Clarify how the `enable-patching` parameter actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then your `composer.patches.json` should look like this:
 
 ## Allowing patches to be applied from dependencies
 
-If you want your project to accept patches from dependencies, you must have the following in your composer file:
+If your project doesn't supply any patches of its own, but you still want to accept patches from dependencies, you must have the following in your composer file:
 
 ```json
 {
@@ -78,6 +78,8 @@ If you want your project to accept patches from dependencies, you must have the 
   }
 }
 ```
+
+If you do have a `patches` section in your composer file that defines your own set of patches then the `enable-patching` setting will be ignored and patches from dependencies will always be applied.
 
 ## Ignoring patches
 


### PR DESCRIPTION
The documentation about the `enable-patching` parameter is worded in a way that implies that it directly controls whether or not patches from dependencies will be applied.

For the 2.x branch we could revisit this and perhaps provide an option `apply-patches-from-dependencies`, but for now let's just update the documentation so it is clear how it works.