### PR TITLE
Fix #174: Compatibility with older Git versions

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -385,8 +385,6 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
             $downloader->copy($hostname, $patch_url, $filename, false);
         }
 
-        // Modified from drush6:make.project.inc
-        $patched = false;
         // The order here is intentional. p1 is most likely to apply with git apply.
         // p0 is next likely. p2 is extremely unlikely, but for some special cases,
         // it might be useful. p4 is useful for Magento 2 patches
@@ -463,6 +461,7 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
             return false;
         }
 
+        $patched = false;
         foreach ($patch_levels as $patch_level) {
             if ($this->io->isVerbose()) {
                 $comment = 'Testing ability to patch with git apply.';

--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -457,6 +457,12 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
      */
     protected function applyPatchWithGit($install_path, $patch_levels, $filename)
     {
+        // Do not use git apply unless the install path is itself a git repo
+        // @see https://stackoverflow.com/a/27283285
+        if (!is_dir($install_path . '/.git')) {
+            return false;
+        }
+
         foreach ($patch_levels as $patch_level) {
             if ($this->io->isVerbose()) {
                 $comment = 'Testing ability to patch with git apply.';


### PR DESCRIPTION
This PR applies the same changes as in #175 but for the current master branch.

It fixes compatibility of composer-patches with older Git versions, as reported in various issues:

- #172 
- #174 
- #216 should become unnecessary as well with this change
