### PR TITLE
Add missing ext-json in composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "require": {
     "php": ">=5.6.0",
+    "ext-json": "*",
     "composer-plugin-api": "^1.0",
     "cweagans/composer-configurable-plugin": "^1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e3ce7bfbafb836928cf5ff88b8edff2",
+    "content-hash": "76327100529583e1383ad9d55bc2d27d",
     "packages": [
         {
             "name": "cweagans/composer-configurable-plugin",
@@ -2318,6 +2318,7 @@
                 "github",
                 "test"
             ],
+            "abandoned": "php-coveralls/php-coveralls",
             "time": "2016-01-20T17:35:46+00:00"
         },
         {
@@ -4352,7 +4353,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.0"
+        "php": ">=5.6.0",
+        "ext-json": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
We are using the PHP function `json_decode` in some places in the code.

Therefore, we need to ensure that users has the proper PHP extension "ext-json".

In order to do that, we need to modify the `composer.json` and add

`"ext-json": "*"`

in the `require` section.