### PR TITLE
Replace --no-backup-if-mismatch with --posix flag

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -426,10 +426,10 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
         // the 'patch' command.
         if (!$patched) {
             foreach ($patch_levels as $patch_level) {
-                // --no-backup-if-mismatch here is a hack that fixes some
-                // differences between how patch works on windows and unix.
+                // --posix is added to patch in order to make sure
+                // patch behaves the same way on windows, linux and unix.
                 if ($patched = $this->executeCommand(
-                    "patch %s --no-backup-if-mismatch -d %s < %s",
+                    "patch %s --posix -d %s < %s",
                     $patch_level,
                     $install_path,
                     $filename


### PR DESCRIPTION
Continuation of abandoned  PR #184 
1.x version: #190 

Currently I have troubles with the tests in the current master branch if I use the `--posix` flag: 

```
  [Exception]                                                                  
  Cannot apply patch Add a startup config for the PHP web server (https://www  
  .drupal.org/files/issues/add_a_startup-1543858-58.patch)!                    
                                                                               
install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
```