### PR TITLE
Fix preserve paths

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -8,10 +8,14 @@
 namespace cweagans\Composer;
 
 use Composer\Composer;
+use Composer\DependencyResolver\DefaultPolicy;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\Repository\CompositeRepository;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
@@ -136,7 +140,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
             || ($has_patches && $has_applied_patches && $tmp_patches[$package_name] !== $extra['patches_applied'])) {
             $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
             $this->io->write('<info>Removing package ' . $package_name . ' so that it can be re-installed and re-patched.</info>');
+            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::PRE_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
             $promises[] = $installationManager->uninstall($localRepository, $uninstallOperation);
+            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::POST_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
           }
         }
       }

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -104,6 +104,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
       $extra = $this->composer->getPackage()->getExtra();
       $patches_ignore = isset($extra['patches-ignore']) ? $extra['patches-ignore'] : array();
+      $installHooks = isset($extra['patches-install-hooks']) ? $extra['patches-install-hooks'] : FALSE;
 
       $tmp_patches = $this->grabPatches();
       foreach ($packages as $package) {
@@ -140,9 +141,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
             || ($has_patches && $has_applied_patches && $tmp_patches[$package_name] !== $extra['patches_applied'])) {
             $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
             $this->io->write('<info>Removing package ' . $package_name . ' so that it can be re-installed and re-patched.</info>');
-            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::PRE_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
-            $promises[] = $installationManager->uninstall($localRepository, $uninstallOperation);
-            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::POST_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
+            if ($installHooks) {
+              $this->eventDispatcher->dispatchPackageEvent(PackageEvents::PRE_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
+            }
+            $promises[] =  $installationManager->uninstall($localRepository, $uninstallOperation);
+            if ($installHooks) {
+              $this->eventDispatcher->dispatchPackageEvent(PackageEvents::POST_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
+            }
           }
         }
       }


### PR DESCRIPTION
Adds a patches-install-hooks setting that controls when this setting is enabled. That way, the risk that this change affects any project that has not specifically enabled it is considerably reduced.

This is still WIP. It needs to also run the POST_PACKAGE_UNINSTALL call whenever the code throws an exception (i.e. when composer-exit-on-patch-failure is set to true).

On hindsight, I should have called it patches-uninstall-hooks...