### PR TITLE
Use empty() instead of isset() to check for empty arrays in RootComposer (test coverage 100%)

### DIFF
--- a/src/Resolvers/RootComposer.php
+++ b/src/Resolvers/RootComposer.php
@@ -22,7 +22,7 @@ class RootComposer extends ResolverBase
 
         $extra = $this->composer->getPackage()->getExtra();
 
-        if (!isset($extra['patches'])) {
+        if (empty($extra['patches'])) {
             return;
         }
 


### PR DESCRIPTION
This gets RootComposer to full coverage.