### PR TITLE
Retry failed downloads once

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -369,7 +369,14 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
       // Download file from remote filesystem to this location.
       $hostname = parse_url($patch_url, PHP_URL_HOST);
-      $downloader->copy($hostname, $patch_url, $filename, FALSE);
+
+      try {
+        $downloader->copy($hostname, $patch_url, $filename, false);
+      } catch (\Exception $e) {
+        // In case of an exception, retry once as the download might
+        // have failed due to intermittent network issues.
+        $downloader->copy($hostname, $patch_url, $filename, false);
+      }
     }
 
     // The order here is intentional. p1 is most likely to apply with git apply.


### PR DESCRIPTION
Same MR as #282, against the 1.x branch.

I think a release soon would be very helpful, the network issues seem to be more frequent. Every other build/deployment today seems to fail.