### PR TITLE
Add support for Composer version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=5.6.0",
     "ext-json": "*",
-    "composer-plugin-api": "^1.0",
+    "composer-plugin-api": "^1.0 || ^2.0",
     "cweagans/composer-configurable-plugin": "^1.0"
   },
   "require-dev": {

--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -511,4 +511,18 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
         }
         return ($this->executor->execute($command, $output) === 0);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
Hi Cameron,
Composer 2 is about to be released, and it has `composer-plugin-api` version 2. This PR updates the version constraint in `composer.json` to `^1 || ^2` so we can support both composer versions.

See [What's new in Composer 2](https://php.watch/articles/composer-2) and [UPGRADE-2.0](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors) for more changes in API. Empty methods \cweagans\Composer\Plugin\Patches::deactivate() and \cweagans\Composer\Plugin\Patches::uninstall are added to make it compatible both versions.

I will make a PR to the `cweagans/composer-configurable-plugin` to update its `composer/composer` version constraint because this package depends on it. 

Related: composer/composer#8726

Thank you 🙏.