### PR TITLE
Support busybox

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "composer-plugin-api": "^1.0"
+    "composer-plugin-api": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "composer/composer": "~1.0",
+    "composer/composer": "^1.0 || ^2.0",
     "phpunit/phpunit": "~4.6"
   },
   "autoload": {

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -404,6 +404,15 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
     }
 
+    // support busybox patch version
+    if (!$patched) {
+      foreach ($patch_levels as $patch_level) {
+        if ($patched = $this->executeCommand("cd %s && patch %s < %s", $install_path, $patch_level, $filename)) {
+          break;
+        }
+      }
+    }
+
     // Clean up the temporary patch file.
     if (isset($hostname)) {
       unlink($filename);


### PR DESCRIPTION
busybox is a sized optimized toolbox of common unix utilities including a version of patch for alpine.
This version doesn't support all parameters so applying patches will fail. This PR introduces another attempt to patch files with params supported by busybox version of patch.

