### PR TITLE
Hotfix for composer preserve paths

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -8,10 +8,14 @@
 namespace cweagans\Composer;
 
 use Composer\Composer;
+use Composer\DependencyResolver\DefaultPolicy;
+use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\Repository\CompositeRepository;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
@@ -119,7 +123,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
             || ($has_patches && $has_applied_patches && $tmp_patches[$package_name] !== $extra['patches_applied'])) {
             $uninstallOperation = new UninstallOperation($package, 'Removing package so it can be re-installed and re-patched.');
             $this->io->write('<info>Removing package ' . $package_name . ' so that it can be re-installed and re-patched.</info>');
+            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::PRE_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
             $installationManager->uninstall($localRepository, $uninstallOperation);
+            $this->eventDispatcher->dispatchPackageEvent(PackageEvents::POST_PACKAGE_UNINSTALL, $event->isDevMode(), new DefaultPolicy(), new Pool('dev'), new CompositeRepository([$package->getRepository()]), new Request(), [$uninstallOperation], $uninstallOperation);
           }
         }
       }


### PR DESCRIPTION
This patch is used in the Drupal 7 composer project: https://github.com/drupal-composer/drupal-project/blob/7.x/composer.json#L76

I am *not* the developer of this commit, @sebCorbin is.

Creating a PR mainly so I can install from a repo instead of having to wait for a patch every time I composer install my D7 stack for devshop: https://github.com/devshop-packages/devshop-control-template 