### PR TITLE
Fix Travis config linter warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+os: linux
 dist: trusty
 
 php:
@@ -11,7 +11,7 @@ env:
   - PATCHES_TEST_SUITE=unit
   - PATCHES_TEST_SUITE=acceptance
 
-matrix:
+jobs:
     fast_finish: true
     allow_failures:
         - php: nightly


### PR DESCRIPTION
Travis said:

- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: missing os, using the default linux
- root: key matrix is an alias for jobs, using jobs

This change fixes those warnings