### PR TITLE
Replace getJobType with an instanceof check

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -176,7 +176,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $operations = $event->getOperations();
     $this->io->write('<info>Gathering patches for dependencies. This might take a minute.</info>');
     foreach ($operations as $operation) {
-      if ($operation->getJobType() == 'install' || $operation->getJobType() == 'update') {
+      if ($operation->getOperationType() == 'install' || $operation->getOperationType() == 'update') {
         $package = $this->getPackageFromOperation($operation);
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -176,7 +176,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $operations = $event->getOperations();
     $this->io->write('<info>Gathering patches for dependencies. This might take a minute.</info>');
     foreach ($operations as $operation) {
-      if ($operation->getOperationType() == 'install' || $operation->getOperationType() == 'update') {
+      if ($operation instanceof InstallOperation || $operation instanceof UpdateOperation) {
         $package = $this->getPackageFromOperation($operation);
         $extra = $package->getExtra();
         if (isset($extra['patches'])) {


### PR DESCRIPTION
Composer 2 has subsequently changed the method name of `getJobType` to `getOperationType` in https://github.com/composer/composer/pull/8537.

The result is I get the error below when trying to run any composer operation that results in a patching operation.
```
PHP Fatal error:  Uncaught Error: Call to undefined method Composer\DependencyResolver\Operation\InstallOperation::getJobType() in /.../vendor/cweagans/composer-patches/src/Patches.php:179
Stack trace:
#0 [internal function]: cweagans\Composer\Patches->gatherPatches(Object(Composer\Installer\PackageEvent))
#1 phar:///.../bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(165): call_user_func(Array, Object(Composer\Installer\PackageEvent))
#2 phar:///.../bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(118): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Installer\PackageEvent))
#3 phar:///.../bin/composer/src/Composer/Installer/InstallationManager.php(368): Composer\EventDispatcher\EventDispatcher->dispatchPackageEvent('pre-package-ins...', true, Object(Composer\Repository\InstalledFilesystemRepository), Array, Object(Composer\DependencyResolver\Operation\InstallOperation in /.../vendor/cweagans/composer-patches/src/Patches.php on line 179
```