### PR TITLE
Fix for outdated patch version on FreeBSD

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -432,12 +432,19 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
         // In some rare cases, git will fail to apply a patch, fallback to using
         // the 'patch' command.
         if (!$patched) {
+            // This is a workaround for the outdated patch version on BSD
+            // systems which doesn't support this option -> use posix then.
+            // --no-backup-if-mismatch here is a hack that fixes some
+            // differences between how patch works on windows and unix.
+            $patch_options = '--no-backup-if-mismatch';
+            if (PHP_OS_FAMILY == 'BSD') {
+                $patch_options = '--posix --batch';
+            }
             foreach ($patch_levels as $patch_level) {
-                // --no-backup-if-mismatch here is a hack that fixes some
-                // differences between how patch works on windows and unix.
                 if ($patched = $this->executeCommand(
-                    "patch %s --no-backup-if-mismatch -d %s < %s",
+                    "patch %s %s -d %s < %s",
                     $patch_level,
+                    $patch_options,
                     $install_path,
                     $filename
                 )


### PR DESCRIPTION
Hi

There are many issues about this topic and many tried to get a fix into the repo. 

#184 This is one of the biggest pull request - it got rejected because of many reasons. Many changed to another project to fix it.

So my approach is to use the `--posix --batch` only when the OS is BSD. That shouldn't break anything and makes everyone happy.

[Even Travis is happy](https://travis-ci.org/github/pesc/composer-patches/builds/740790498)

@cweagans Please let me know what you think about this approach. Will then submit a fix for 1.x too