### PR TITLE
#258 Added a flag to skip reporting on applied patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ To enforce throwing an error and stopping package installation/update immediatel
 
 By default, failed patches are skipped.
 
+## Patches reporting
+
+When a patch is applied, the plugin writes a report-file `PATCHES.txt` to a patching directory (e.g. `./patch-me/PATCHES.txt`),
+which contains a list of applied patches.
+
+If you want to avoid this behavior, add a specific key to the `extra` section:
+```json
+"extra": {
+    "composer-patches-skip-reporting": true
+}
+```
+
+Or provide an environment variable `COMPOSER_PATCHES_SKIP_REPORTING` with a config.
+
 ## Difference between this and netresearch/composer-patches-plugin
 
 - This plugin is much more simple to use and maintain

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -278,6 +278,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // Check if we should exit in failure.
     $extra = $this->composer->getPackage()->getExtra();
     $exitOnFailure = getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') || !empty($extra['composer-exit-on-patch-failure']);
+    $skipReporting = getenv('COMPOSER_PATCHES_SKIP_REPORTING') || !empty($extra['composer-patches-skip-reporting']);
 
     // Get the package object for the current operation.
     $operation = $event->getOperation();
@@ -324,7 +325,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $localPackage->setExtra($extra);
 
     $this->io->write('');
-    $this->writePatchReport($this->patches[$package_name], $install_path);
+
+    if (true !== $skipReporting) {
+      $this->writePatchReport($this->patches[$package_name], $install_path);
+    }
   }
 
   /**


### PR DESCRIPTION
According to #258, provided a way to avoid reporting, by using a flag `composer-patches-skip-reporting` with value `true`, or an env-variable `COMPOSER_PATCHES_SKIP_REPORTING`. 

Used similar approach with the `composer-exit-on-patch-failure` flag.

Added a how-to description to the README.

No backward-compatibility brakes. 