### PR TITLE
Adds patch options support, with binary option already implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,40 @@ Composer [blocks](https://getcomposer.org/doc/06-config.md#secure-http) you from
 
 However, it's always advised to setup HTTPS to prevent MITM code injection.
 
+## Apply binary patches
+
+Binary patches can be useful if you have to apply a patch to a module with
+Windows line separator on a Unix environment. 
+
+Example composer.json:
+
+```json
+{
+  "require": {
+    "cweagans/composer-patches": "~1.0",
+    "drupal/core-recommended": "^8.8",
+  },
+  "config": {
+    "preferred-install": "source"
+  },
+  "extra": {
+    "patches": {
+      "drupal/core": {
+        "Add startup configuration for PHP server": "https://www.drupal.org/files/issues/add_a_startup-1543858-30.patch"
+      }
+    },
+    "patches-options": {
+      "drupal/core": {
+        "https://www.drupal.org/files/issues/add_a_startup-1543858-30.patch": {
+          "binary": true
+        }
+      }
+    }
+  }
+}
+
+```
+
 ## Patches containing modifications to composer.json files
 
 Because patching occurs _after_ Composer calculates dependencies and installs packages, changes to an underlying dependency's `composer.json` file introduced in a patch will have _no effect_ on installed packages.

--- a/src/PatchOptions.php
+++ b/src/PatchOptions.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace cweagans\Composer;
+
+class PatchOptions implements \JsonSerializable
+{
+    /**
+     * The package that the patch belongs to.
+     *
+     * @var string $package
+     */
+    public $package;
+
+    /**
+     * The URL where the patch is stored. Can be local.
+     *
+     * @var string $url
+     */
+    public $url;
+
+    /**
+     * Should we do binary mode?
+     *
+     * @var boolean $binary
+     */
+    public $binary;
+
+    /**
+     * Create a Patch from a serialized representation.
+     *
+     * @param $json
+     *   A json_encode'd representation of a Patch.
+     *
+     * @return PatchOptions
+     *   A Patch with all of the serialized properties set.
+     */
+    public static function fromJson($json)
+    {
+        if (!is_object($json)) {
+            $json = json_decode($json);
+        }
+        $properties = ['package', 'url', 'binary'];
+        $patchOptions = new static();
+
+        foreach ($properties as $property) {
+            if (isset($json->{$property})) {
+                $patchOptions->{$property} = $json->{$property};
+            }
+        }
+
+        return $patchOptions;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'package' => $this->package,
+            'url' => $this->url,
+            'binary' => $this->binary
+        ];
+    }
+}

--- a/src/PatchOptionsCollection.php
+++ b/src/PatchOptionsCollection.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace cweagans\Composer;
+
+class PatchOptionsCollection implements \JsonSerializable
+{
+    /**
+     * A deep list of patches to apply.
+     *
+     * Keys are package names. Values are arrays of Patch objects.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Add a patch to the collection.
+     *
+     * @param PatchOptions $option
+     *   The patch object to add to the collection.
+     */
+    public function addOptions(PatchOptions $option)
+    {
+        $this->options[$option->package][$option->url] = $option;
+    }
+
+    /**
+     * Retrieve a list of options for a given package.
+     *
+     * @param string $package
+     *   The package name to get options for.
+     *
+     * @return PatchOptions|null
+     *   A PatchOptions or null if none are found
+     */
+    public function getOptionsForPatch($package, $url)
+    {
+        if (isset($this->options[$package][$url])) {
+            return $this->options[$package][$url];
+        }
+
+        return;
+    }
+
+    /**
+     * Create a PatchCollection from a serialized representation.
+     *
+     * @param $json
+     *   A json_encode'd representation of a PatchCollection.
+     *
+     * @return PatchOptionsCollection
+     *   A PatchOptionsCollection with all of the serialized options included.
+     */
+    public static function fromJson($json)
+    {
+        if (!is_object($json)) {
+            $json = json_decode($json);
+        }
+        $collection = new static();
+
+        foreach ($json->options as $package => $options) {
+            foreach ($options as $patch_json) {
+                $patch = Patch::fromJson($patch_json);
+                $collection->addPatchOptions($patch);
+            }
+        }
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'patches-options' => $this->options,
+        ];
+    }
+}

--- a/src/Resolvers/PatchesFile.php
+++ b/src/Resolvers/PatchesFile.php
@@ -10,6 +10,7 @@ namespace cweagans\Composer\Resolvers;
 use Composer\Installer\PackageEvent;
 use cweagans\Composer\Patch;
 use cweagans\Composer\PatchCollection;
+use cweagans\Composer\PatchOptionsCollection;
 
 class PatchesFile extends ResolverBase
 {
@@ -37,6 +38,23 @@ class PatchesFile extends ResolverBase
             foreach ($patches as $patch) {
                 /** @var Patch $patch */
                 $collection->addPatch($patch);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolveOptions(PatchOptionsCollection $options_collection, PackageEvent $event)
+    {
+        $extra = $this->composer->getPackage()->getExtra();
+        if (empty($extra['patches-options'])) {
+            return;
+        }
+        foreach ($this->findPatchesOptionsInJson($extra['patches-options']) as $package => $patches_options) {
+            foreach ($patches_options as $patch_options) {
+                /** @var Patch $patch */
+                $options_collection->addOptions($patch_options);
             }
         }
     }

--- a/src/Resolvers/ResolverInterface.php
+++ b/src/Resolvers/ResolverInterface.php
@@ -11,6 +11,7 @@ use Composer\Composer;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use cweagans\Composer\PatchCollection;
+use cweagans\Composer\PatchOptionsCollection;
 
 interface ResolverInterface
 {
@@ -39,4 +40,18 @@ interface ResolverInterface
      * @return mixed
      */
     public function resolve(PatchCollection $collection, PackageEvent $event);
+
+    /**
+     * Find and add patches options to the supplied PatchOptionsCollection.
+     *
+     * Note that in this method, it is safe to assume that the resolver is enabled
+     * because this method will never be called if ::isEnabled() returns FALSE.
+     *
+     * @param PatchOptionsCollection $options_collection
+     *   A collection of patches options to use when to apply the patch
+     * @param PackageEvent $event
+     *   The event that's currently being responded to.
+     * @return mixed
+     */
+    public function resolveOptions(PatchOptionsCollection $options_collection, PackageEvent $event);
 }

--- a/src/Resolvers/RootComposer.php
+++ b/src/Resolvers/RootComposer.php
@@ -10,6 +10,7 @@ namespace cweagans\Composer\Resolvers;
 use Composer\Installer\PackageEvent;
 use cweagans\Composer\Patch;
 use cweagans\Composer\PatchCollection;
+use cweagans\Composer\PatchOptionsCollection;
 
 class RootComposer extends ResolverBase
 {
@@ -30,6 +31,23 @@ class RootComposer extends ResolverBase
             foreach ($patches as $patch) {
                 /** @var Patch $patch */
                 $collection->addPatch($patch);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolveOptions(PatchOptionsCollection $options_collection, PackageEvent $event)
+    {
+        $extra = $this->composer->getPackage()->getExtra();
+        if (empty($extra['patches-options'])) {
+            return;
+        }
+        foreach ($this->findPatchesOptionsInJson($extra['patches-options']) as $package => $patches_options) {
+            foreach ($patches_options as $patch_options) {
+                /** @var Patch $patch */
+                $options_collection->addOptions($patch_options);
             }
         }
     }


### PR DESCRIPTION
Hi, I need the ability to patch some module made in code with \r\l line endings. The only clean way to do it, without using git apply, is to use the binary option on patch. With git apply you can prepare a binary patch with git format-patch, but I cannot do it because our module is not versioned with git. What a wild world we live in!
So my only option was to fork your nice code and try to add the ability to specify some patches as binary.
Let me know if there are things that you don't like and should be fixed, thanks!