### PR TITLE
#244 add ignore-whitespace config for patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ Its useful for packages like drupal/core which packages only a subdir of the ori
 }
 ```
 
+## Ignoring whitespace for patches (--ignore-whitespace)
+
+In some cases, patches won't apply correctly if the original file has some weird whitespace stuff going on. This option can help mitigate those issues.
+
+```json
+{
+  "extra": {
+    "ignoreWhitespace": {
+      "drupal/example-module": true
+    }
+  }
+}
+```
+
 ## Using patches from HTTP URLs
 
 Composer [blocks](https://getcomposer.org/doc/06-config.md#secure-http) you from downloading anything from HTTP URLs, you can disable this for your project by adding a `secure-http` setting in the config section of your `composer.json`. Note that the `config` section should be under the root of your `composer.json`.

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -392,14 +392,18 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // p0 is next likely. p2 is extremely unlikely, but for some special cases,
     // it might be useful. p4 is useful for Magento 2 patches
     $patch_levels = array('-p1', '-p0', '-p2', '-p4');
+    $ignore_whitespace = false;
 
     // Check for specified patch level for this package.
     $extra = $this->composer->getPackage()->getExtra();
     if (!empty($extra['patchLevel'][$package->getName()])){
       $patch_levels = array($extra['patchLevel'][$package->getName()]);
     }
+    if (!empty($extra['ignoreWhitespace'][$package->getName()])){
+      $ignore_whitespace = array($extra['ignoreWhitespace'][$package->getName()]);
+    }
     // Attempt to apply with git apply.
-    $patched = $this->applyPatchWithGit($install_path, $patch_levels, $filename);
+    $patched = $this->applyPatchWithGit($install_path, $patch_levels, $ignore_whitespace, $filename);
 
     // In some rare cases, git will fail to apply a patch, fallback to using
     // the 'patch' command.
@@ -407,7 +411,12 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       foreach ($patch_levels as $patch_level) {
         // --no-backup-if-mismatch here is a hack that fixes some
         // differences between how patch works on windows and unix.
-        if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+        if ($ignore_whitespace) {
+          $patched = $this->executeCommand("patch %s --ignore-whitespace --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename);
+        } else {
+          $patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename);
+        }
+        if ($patched) {
           break;
         }
       }
@@ -533,7 +542,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
    * @return bool
    *   TRUE if patch was applied, FALSE otherwise.
    */
-  protected function applyPatchWithGit($install_path, $patch_levels, $filename) {
+  protected function applyPatchWithGit($install_path, $patch_levels, $ignore_whitespace, $filename) {
     // Do not use git apply unless the install path is itself a git repo
     // @see https://stackoverflow.com/a/27283285
     if (!is_dir($install_path . '/.git')) {
@@ -547,7 +556,13 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $comment .= ' This command may produce errors that can be safely ignored.';
         $this->io->write('<comment>' . $comment . '</comment>');
       }
-      $checked = $this->executeCommand('git -C %s apply --check -v %s %s', $install_path, $patch_level, $filename);
+
+      if ($ignore_whitespace) {
+        $checked = $this->executeCommand('git -C %s apply --check --ignore-whitespace -v %s %s', $install_path, $patch_level, $filename);
+      } else {
+        $checked = $this->executeCommand('git -C %s apply --check -v %s %s', $install_path, $patch_level, $filename);
+      }
+
       $output = $this->executor->getErrorOutput();
       if (substr($output, 0, 7) == 'Skipped') {
         // Git will indicate success but silently skip patches in some scenarios.
@@ -557,7 +572,11 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
       if ($checked) {
         // Apply the first successful style.
-        $patched = $this->executeCommand('git -C %s apply %s %s', $install_path, $patch_level, $filename);
+        if ($ignore_whitespace) {
+          $patched = $this->executeCommand('git -C %s apply --ignore-whitespace %s %s', $install_path, $patch_level, $filename);
+        } else {
+          $patched = $this->executeCommand('git -C %s apply %s %s', $install_path, $patch_level, $filename);
+        }
         break;
       }
     }


### PR DESCRIPTION
This patch adds a config option that adds `--whitespace-ignore` to its patch application commands. 

Without that flag, a few of my patches would fail to apply, specifically to some minified js from a drupal contrib module. 

I also updated the readme with instructions on how to use the setting. 

I'd love to add this to the 2.x version as well, though I don't believe there's currently the option to set config on a per-package basis there as there is on the 1.x branch (like the patch-level/patchLevel option). 

It's implemented by choosing between two versions of the command based on the config setting instead of just another argument like the patchLevel one as if it's disabled, it would pass in `''` as an the argument, which gets misinterpreted as the patch filename. If there's a better way to do this, feel free to let me know. 