### PR TITLE
Use the -i flag for input file, and do not pipe via stdin.

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -441,7 +441,7 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
                 // --no-backup-if-mismatch here is a hack that fixes some
                 // differences between how patch works on windows and unix.
                 if ($patched = $this->executeCommand(
-                    "patch %s --no-backup-if-mismatch -d %s < %s",
+                    "patch %s --no-backup-if-mismatch -d %s -i %s",
                     $patch_level,
                     $install_path,
                     $filename


### PR DESCRIPTION
Turns out that under docker (on GitHub Actions for one) stdin does not
behave the way we would like. Although patching suceeds, the command
returns an error code and composer exits. Using the `-i` option to
specify the input file resolves this issue and is not less compatible.