### PR TITLE
Add a method to tell if a package has been patched

### DIFF
--- a/src/Patch.php
+++ b/src/Patch.php
@@ -2,6 +2,8 @@
 
 namespace cweagans\Composer;
 
+use Composer\Package\PackageInterface;
+
 class Patch implements \JsonSerializable
 {
     /**
@@ -77,5 +79,18 @@ class Patch implements \JsonSerializable
             'sha1' => $this->sha1,
             'depth' => $this->depth,
         ];
+    }
+
+  /**
+   * Indicates if a package has been patched.
+   *
+   * @param \Composer\Package\PackageInterface $package
+   *   The package to check.
+   *
+   * @return bool
+   *   TRUE if the package has been patched.
+   */
+    public static function isPackagePatched(PackageInterface $package) {
+      return array_key_exists('patches_applied', $package->getExtra());
     }
 }


### PR DESCRIPTION
For the purposes of Drupal's auto-updates initiative, it would be really useful to us to have an API method in this plugin which can tell us if an installed package has been patched. We could just check the presence of the `extra.patches_applied` key -- and indeed, we do -- but we'd rather the plugin exposed an API for this, so we don't have to rely on internal keys. So this PR adds a `Patch::isPackagePatched()` method for this purpose.

See related discussion in https://www.drupal.org/project/automatic_updates/issues/3252299.