### PR TITLE
Backward compatibility of #334 for 1.x

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -409,7 +409,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       // --no-backup-if-mismatch here is a hack that fixes some
       // differences between how patch works on windows and unix.
       $patch_options = '--no-backup-if-mismatch';
-      if (PHP_OS_FAMILY == 'BSD') {
+      if (PHP_OS_FAMILY == 'BSD' || PHP_OS == ('FreeBSD' || 'NetBSD' || 'OpenBSD')) {
           $patch_options = '--posix --batch';
       }
       foreach ($patch_levels as $patch_level) {

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -395,10 +395,16 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // In some rare cases, git will fail to apply a patch, fallback to using
     // the 'patch' command.
     if (!$patched) {
+      // This is a workaround for the outdated patch version on BSD
+      // systems which doesn't support this option -> use posix then.
+      // --no-backup-if-mismatch here is a hack that fixes some
+      // differences between how patch works on windows and unix.
+      $patch_options = '--no-backup-if-mismatch';
+      if (PHP_OS_FAMILY == 'BSD') {
+          $patch_options = '--posix --batch';
+      }
       foreach ($patch_levels as $patch_level) {
-        // --no-backup-if-mismatch here is a hack that fixes some
-        // differences between how patch works on windows and unix.
-        if ($patched = $this->executeCommand("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $install_path, $filename)) {
+        if ($patched = $this->executeCommand("patch %s %s -d %s < %s", $patch_level, $patch_options, $install_path, $filename)) {
           break;
         }
       }


### PR DESCRIPTION
Hi

Some time ago, I've created the pull request: #334 which was merged to master branch. The problem is, the most used version is 1.x. So we need to fix it for this version too. Cherry-picking wasn't a option, because the #334 version only works for PHP 7.2+.

So my approach is based on the new `PHP_OS_FAMILY` (PHP 7.2+) mixed with older `PHP_OS` detection and the help of this issue: https://github.com/sebastianbergmann/environment/issues/21

@cweagans What do you think?

manual of `patch`:
https://man.netbsd.org/patch.1
https://man.openbsd.org/patch.1
https://www.freebsd.org/cgi/man.cgi?patch(1)