### PR TITLE
Add installedPatches property to fix PHP 8.2 deprecation

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -65,6 +65,11 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
      * @var array $patches
      */
     protected $patches;
+    
+    /**
+     * @var array $installedPatches
+     */
+    protected $installedPatches;
 
     /**
      * @var bool $patchesResolved


### PR DESCRIPTION
There is a deprecation notice with PHP 8.2

Deprecation Notice: Creation of dynamic property cweagans\Composer\Patches::$installedPatches is deprecated in /Users/shyim/Code/sw6/vendor/cweagans/composer-patches/src/Patches.php:63