### PR TITLE
Communicate that patch failed due to missing 'patch' command

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -404,6 +404,10 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // In some rare cases, git will fail to apply a patch, fallback to using
     // the 'patch' command.
     if (!$patched) {
+      if (!$this->executeCommand('patch -v')) {
+        throw new \Exception('Failed to run the "patch" command. Is it installed on the system?');
+      }
+
       foreach ($patch_levels as $patch_level) {
         // --no-backup-if-mismatch here is a hack that fixes some
         // differences between how patch works on windows and unix.


### PR DESCRIPTION
## Problem
When attempting to use this package on a system that does not have the "patch" command installed, you get a vague error message:

> Could not apply patch! Skipping. The error was: Cannot apply patch ######

## Cause
I spend a long time trying to work out exactly why my patch was not applying. Thinking that it was a problem with the patch file itself. But eventually, I discovered that the package is assuming the system has a "patch" command.

##
Check if the patch command is present and can be run before trying to use it. If that fails, then clearly communicate to the user what the problem is so they can resolve it:

> Could not apply patch! Skipping. The error was: Failed to run the "patch" command. Is it installed on the system?