### PR TITLE
How to store links to issues in patch description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Example composer.json:
 
 ```
 
+It's also useful to add a link to the original issue, to have a quick way for checking new patch versions. You can integrate the link into the patch description like this:
+```json
+      "drupal/core": {
+        "Add startup configuration for PHP server - https://www.drupal.org/project/drupal/issues/1543858": "https://www.drupal.org/files/issues/add_a_startup-1543858-30.patch"
+      }
+```
+
 ## Using an external patch file
 
 Instead of a patches key in your root composer.json, use a patches-file key.


### PR DESCRIPTION
Added an example how we can store links to issues in patch description. 

It's very useful to have a direct link, because very often we can't quickly jump onto related issue page from the patch file URL.

For example to open the related url from the `https://www.drupal.org/files/issues/add_a_startup-1543858-30.patch` patch - you need to manually extract the node id (`1543858`) and compose the url like this: `https://www.drupal.org/project/drupal/issues/1543858`.

Via the direct link you can simply click on the link and check the issue page for new versions of the patch.