### PR TITLE
fix: add non-dynamic property for $installedPatches

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -65,6 +65,11 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
      * @var array $patches
      */
     protected $patches;
+    
+    /**
+     * @var array $installedPatches
+     */
+    protected $installedPatches;
 
     /**
      * @var bool $patchesResolved


### PR DESCRIPTION
This removes the deprecation notice about creation of a dynamic property.