### PR TITLE
Only read patches-file if it has expected type

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -238,7 +238,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       return $patches;
     }
     // If it's not specified there, look for a patches-file definition.
-    elseif (isset($extra['patches-file'])) {
+    elseif (isset($extra['patches-file']) && is_string($extra['patches-file'])) {
       $this->io->write('<info>Gathering patches from patch file.</info>');
       $patches = file_get_contents($extra['patches-file']);
       $patches = json_decode($patches, TRUE);


### PR DESCRIPTION
I have recently picked up a project which uses `vaimo/composer-patches`. I use `cweagans/composer-patches` in my global Composer (ie, `~/.composer/`; to back-port a bug fix that the vendor has not yet accepted). However, when working with this project, I get an error message because `cweagans/composer-patches` is trying to parse `extra.patches-file` as a string, but `vaimo/composer-patches` defines this as an array.

![Screenshot_2022-12-29_15-21-17](https://user-images.githubusercontent.com/334786/209973845-1ee2b4d6-d41a-4a90-822c-4583596b4ea1.png)

```
Gathering patches from patch file.

In Patches.php line 243:
                                                                                    
  [TypeError]                                                                       
  file_get_contents(): Argument #1 ($filename) must be of type string, array given  
                                                                                    

Exception trace:
  at /home/fredden/.composer/vendor/cweagans/composer-patches/src/Patches.php:243
 file_get_contents() at /home/fredden/.composer/vendor/cweagans/composer-patches/src/Patches.php:243
 cweagans\Composer\Patches->grabPatches() at /home/fredden/.composer/vendor/cweagans/composer-patches/src/Patches.php:109
 cweagans\Composer\Patches->checkPatches() at phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:206
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:129
 Composer\EventDispatcher\EventDispatcher->dispatchScript() at phar:///usr/local/bin/composer/src/Composer/Installer.php:277
 Composer\Installer->run() at phar:///usr/local/bin/composer/src/Composer/Command/InstallCommand.php:146
 Composer\Command\InstallCommand->execute() at phar:///usr/local/bin/composer/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:1040
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:301
 Symfony\Component\Console\Application->doRun() at phar:///usr/local/bin/composer/src/Composer/Console/Application.php:377
 Composer\Console\Application->doRun() at phar:///usr/local/bin/composer/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at phar:///usr/local/bin/composer/src/Composer/Console/Application.php:141
 Composer\Console\Application->run() at phar:///usr/local/bin/composer/bin/composer:88
 require() at /usr/local/bin/composer:29

install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
```

PHP version 8.2.0
Composer version 2.5.1
`cweagans/composer-patches` version 1.7.3