### PR TITLE
Fix #423: Patching stalls on Ventura

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -451,16 +451,13 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
             // systems which doesn't support this option -> use posix then.
             // --no-backup-if-mismatch here is a hack that fixes some
             // differences between how patch works on windows and unix.
-            $patch_options = '--no-backup-if-mismatch';
-            if (PHP_OS_FAMILY == 'BSD') {
-                $patch_options = '--posix --batch';
-            }
             foreach ($patch_levels as $patch_level) {
                 if (
                     $patched = $this->executeCommand(
-                        "patch %s %s -d %s < %s",
+                        "patch %s %s %s -d %s < %s",
                         $patch_level,
-                        $patch_options,
+                        '--batch',
+                        '--no-backup-if-mismatch',
                         $install_path,
                         $filename
                     )


### PR DESCRIPTION
tl;dr: newer `patch` versions on Mac appear to require the `--batch` option, otherwise they stall awaiting input of a filename to patch.

I tested with Ventura and gpatch, both have the `--batch` option so it should be safe to use universally, but to be extra safe I include a check that it's supported.

Note that this would have _almost_ worked with the existing code, except for two bugs:

- PHP_OS_FAMILY is unreliable and returns the OS of where PHP was built, not where it runs, and in any case should be checking for `Darwin` on mac
- `--posix --batch` was getting quoted as a single flag and causing `patch` to error.

Note that to test this properly, you'll need to either have a patch that fails Git patching (so it falls through to the patch utility), or you can comment out / delete the Git patch methods.