### PR TITLE
Run all patchers in verbose mode

### DIFF
--- a/src/Patcher/BsdPatchPatcher.php
+++ b/src/Patcher/BsdPatchPatcher.php
@@ -15,7 +15,7 @@ class BsdPatchPatcher extends PatcherBase
         // TODO: Dry run first?
 
         return $this->executeCommand(
-            '%s -p%s --posix --batch -d %s -i %s',
+            '%s -p%s --verbose --posix --batch -d %s -i %s',
             $this->patchTool(),
             $patch->depth,
             $path,

--- a/src/Patcher/GitPatcher.php
+++ b/src/Patcher/GitPatcher.php
@@ -39,7 +39,7 @@ class GitPatcher extends PatcherBase
 
         // Otherwise, we can try to apply the patch.
         return $this->executeCommand(
-            '%s -C %s apply -p%s %s',
+            '%s -C %s apply -p%s --verbose %s',
             $this->patchTool(),
             $path,
             $patch->depth,

--- a/src/Patcher/GnuPatchPatcher.php
+++ b/src/Patcher/GnuPatchPatcher.php
@@ -14,7 +14,7 @@ class GnuPatchPatcher extends PatcherBase
         // TODO: Dry run first?
 
         return $this->executeCommand(
-            '%s -p%s --no-backup-if-mismatch -d %s -i %s',
+            '%s -p%s --no-backup-if-mismatch --verbose -d %s -i %s',
             $this->patchTool(),
             $patch->depth,
             $path,


### PR DESCRIPTION
Turns out this is a little easier than I anticipated because the output is only shown when -v is passed to composer anyway. We can just _always_ run the patchers in verbose mode and call it a day.