### PR TITLE
Add new patcher: git 'init' patcher

### DIFF
--- a/docs/troubleshooting/guide.md
+++ b/docs/troubleshooting/guide.md
@@ -20,11 +20,6 @@ See the [system requirements]({{< relref "../getting-started/system-requirements
 Composer Patches requires at least _some_ mechanism for applying patches. If you don't have any installed, you'll see a fair number of errors. You should install some combination of GNU `patch`, BSD `patch`, `git`, or other applicable software. macOS users commonly need to `brew install gpatch` to get a modern version of `patch` on their system.
 
 
-## Set `preferred-install` to `source`
-
-The Git patcher included with this plugin is the most reliable method of applying patches. However, the Git patcher won't even _attempt_ to apply a patch if the target directory isn't cloned from Git. To avoid this situation, you should either set `"preferred-install": "source"` or set specific packages to be installed from source in your Composer configuration. Patches may still be successfully applied without this setting, but if you're working on a team, you'll have much more consistent results with the Git patcher.
-
-
 ## Download patches securely
 
 If you've been referred here, you're trying to download patches over HTTP without explicitly telling Composer that you want to do that. See the [`secure-http`]({{< relref "../usage/configuration.md#secure-http" >}}) documentation for more information.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -133,6 +133,7 @@ You probably don't need to change this value unless you're building a plugin tha
             "disable-patchers": [
                 "\\cweagans\\Composer\\Patcher\\BsdPatchPatcher",
                 "\\cweagans\\Composer\\Patcher\\GitPatcher",
+                "\\cweagans\\Composer\\Patcher\\GitInitPatcher",
                 "\\cweagans\\Composer\\Patcher\\GnuGPatchPatcher",
                 "\\cweagans\\Composer\\Patcher\\GnuPatchPatcher"
             ]
@@ -147,29 +148,12 @@ You probably don't need to change this value unless you're building a plugin tha
  
 For completeness, all of the patchers that ship with the plugin are listed above, but you should _not_ list all of them. If no patchers are available, the plugin will throw an exception during `composer install`.
 
+`GitPatcher` and `GitInitPatcher` should be enabled and disabled together -- don't disable one without the other.
+
 After changing this value, you should re-lock and re-apply patches to your project.
 
 
 ## Relevant configuration provided by Composer
-
-### `preferred-install`
-
-```json
-{
-    [...],
-    "config": {
-        "preferred-install": "source"
-    }
-}
-```
-
-**Default value**: `"dist"`
-
-The relevant Composer documentation for this parameter can be found [here](https://getcomposer.org/doc/06-config.md#preferred-install).
-
-If you're applying patches that were generated with `git`, setting `preferred-install` to `"source"` is **highly recommended** (either by changing the setting for all packages or by setting that value on a per-package basis as shown in the Composer documentation. This will allow the `GitPatcher` to apply patches as often as possible (the `GitPatcher` won't even _attempt_ to apply a patch if the target directory isn't managed by `git`). Git is the most reliable patcher available to Composer Patches. _Not_ changing this setting will result in other patchers attempting to apply patches. Historically, these patchers have had varying degrees of success depending on a number of factors, so it's better to use the `GitPatcher` when you're able to do so.
-
----
 
 ### `secure-http`
 

--- a/src/Capability/Patcher/CorePatcherProvider.php
+++ b/src/Capability/Patcher/CorePatcherProvider.php
@@ -4,6 +4,7 @@ namespace cweagans\Composer\Capability\Patcher;
 
 use cweagans\Composer\Patcher\BsdPatchPatcher;
 use cweagans\Composer\Patcher\GitPatcher;
+use cweagans\Composer\Patcher\GitInitPatcher;
 use cweagans\Composer\Patcher\GnuGPatchPatcher;
 use cweagans\Composer\Patcher\GnuPatchPatcher;
 
@@ -16,6 +17,7 @@ class CorePatcherProvider extends BasePatcherProvider
     {
         return [
             new GitPatcher($this->composer, $this->io),
+            new GitInitPatcher($this->composer, $this->io),
             new GnuPatchPatcher($this->composer, $this->io),
             new GnuGPatchPatcher($this->composer, $this->io),
             new BsdPatchPatcher($this->composer, $this->io),

--- a/src/Command/DoctorCommand.php
+++ b/src/Command/DoctorCommand.php
@@ -109,66 +109,6 @@ class DoctorCommand extends PatchesCommandBase
         $io->write("");
         $io->write("<info>Common configuration issues</info>");
         $io->write("================================================================================");
-        $preferred_install_issues = false;
-        $pi = $composer->getConfig()->get('preferred-install');
-        $io->write(
-            str_pad("preferred-install is set:", 77) . (is_null($pi) ? " <warning>no</warning>" : "<info>yes</info>")
-        );
-
-        if (is_null($pi)) {
-            $preferred_install_issues = true;
-        }
-
-        if (is_string($pi)) {
-            $io->write(
-                str_pad("preferred-install set to 'source' for all/some packages:", 77) .
-                ($pi === "source" ? "<info>yes</info>" : " <warning>no</warning>")
-            );
-        }
-
-        if (is_string($pi) && $pi !== "source") {
-            $preferred_install_issues = true;
-        }
-
-        if (is_array($pi)) {
-            $patched_packages = $plugin->getPatchCollection()->getPatchedPackages();
-            foreach ($patched_packages as $package) {
-                if (in_array($package, array_values($pi))) {
-                    $io->write(
-                        str_pad("preferred-install set to 'source' for $package:", 77) . "<info>yes</info>"
-                    );
-                    continue;
-                }
-
-                foreach ($pi as $pattern => $value) {
-                    $pattern = strtr($pattern, ['*' => '.*', '/' => '\/']);
-                    if (preg_match("/$pattern/", $package)) {
-                        $io->write(
-                            str_pad("preferred-install set to 'source' for $package:", 77) .
-                            ($value === "source" ? "<info>yes</info>" : " <warning>no</warning>")
-                        );
-
-                        if ($value !== "source") {
-                            $preferred_install_issues = true;
-                        }
-
-                        break 2;
-                    }
-                }
-
-                $preferred_install_issues = true;
-            }
-        }
-
-        if ($preferred_install_issues) {
-            $suggestions[] = [
-                "message" => "Setting 'preferred-install' to 'source' either globally or for each patched dependency " .
-                    "is highly recommended for consistent results",
-                "link" =>
-                    "https://docs.cweagans.net/composer-patches/troubleshooting/guide#set-preferred-install-to-source"
-            ];
-        }
-
         $has_http_urls = false;
         foreach ($plugin->getPatchCollection()->getPatchedPackages() as $package) {
             foreach ($plugin->getPatchCollection()->getPatchesForPackage($package) as $patch) {

--- a/src/Patcher/GitInitPatcher.php
+++ b/src/Patcher/GitInitPatcher.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace cweagans\Composer\Patcher;
+
+use Composer\IO\IOInterface;
+use cweagans\Composer\Patch;
+
+class GitInitPatcher extends GitPatcher
+{
+    public function apply(Patch $patch, string $path): bool
+    {
+        // If the target is already a git repo, the standard Git patcher can handle it.
+        if (is_dir($path . '/.git')) {
+            return false;
+        }
+
+        $this->io->write("Creating temporary fake git repo in $path to apply patch", true, IOInterface::VERBOSE);
+
+        // Create a fake Git repo -- just enough to make Git think it's looking at a real repo.
+        $dirs = [
+            $path . '/.git',
+            $path . '/.git/objects',
+            $path . '/.git/refs',
+        ];
+        foreach ($dirs as $dir) {
+            mkdir($dir);
+        }
+        file_put_contents($path . '/.git/HEAD', "ref: refs/heads/main");
+
+
+        // Use the git patcher to apply the patch.
+        $status = parent::apply($patch, $path);
+
+        // Clean up the fake git repo.
+        unlink($path . '/.git/HEAD');
+        foreach (array_reverse($dirs) as $dir) {
+            rmdir($dir);
+        }
+
+        return $status;
+    }
+}

--- a/src/Patcher/GitPatcher.php
+++ b/src/Patcher/GitPatcher.php
@@ -14,6 +14,7 @@ class GitPatcher extends PatcherBase
         // If the path isn't a git repo, don't even try.
         // @see https://stackoverflow.com/a/27283285
         if (!is_dir($path . '/.git')) {
+            $this->io->write("$path is not a git repo. Skipping Git patcher.", true, IOInterface::VERBOSE);
             return false;
         }
 

--- a/tests/_data/fixtures/apply-git-patch-from-web-using-init/composer.json
+++ b/tests/_data/fixtures/apply-git-patch-from-web-using-init/composer.json
@@ -1,0 +1,36 @@
+{
+  "name": "cweagans/composer-patches-test-project",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../../../"
+    }
+  ],
+  "require": {
+    "cweagans/composer-patches": "*@dev",
+    "cweagans/composer-patches-testrepo": "~1.0"
+  },
+  "extra": {
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Add a file": "https://patch-diff.githubusercontent.com/raw/cweagans/composer-patches-testrepo/pull/1.patch"
+      }
+    }
+  },
+  "config": {
+    "preferred-install": "dist",
+    "composer-patches": {
+      "disable-patchers": [
+        "\\cweagans\\Composer\\Patcher\\BsdPatchPatcher",
+        "\\cweagans\\Composer\\Patcher\\GnuGPatchPatcher",
+        "\\cweagans\\Composer\\Patcher\\GnuPatchPatcher"
+      ]
+    },
+    "allow-plugins": {
+      "cweagans/composer-patches": true
+    }
+  }
+}

--- a/tests/_data/fixtures/no-patchers-available/composer.json
+++ b/tests/_data/fixtures/no-patchers-available/composer.json
@@ -18,6 +18,7 @@
       "disable-patchers": [
         "cweagans\\Composer\\Patcher\\BsdPatchPatcher",
         "cweagans\\Composer\\Patcher\\GitPatcher",
+        "cweagans\\Composer\\Patcher\\GitInitPatcher",
         "cweagans\\Composer\\Patcher\\GnuGPatchPatcher",
         "cweagans\\Composer\\Patcher\\GnuPatchPatcher"
       ]

--- a/tests/acceptance/ApplyGitPatchFromWebUsingInitCept.php
+++ b/tests/acceptance/ApplyGitPatchFromWebUsingInitCept.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @var \Codeception\Scenario $scenario
+ */
+
+use cweagans\Composer\Tests\AcceptanceTester;
+
+$I = new AcceptanceTester($scenario);
+$I->wantTo('modify a package using a patch downloaded from the internet (exercising Git init patcher)');
+$I->amInPath(codecept_data_dir('fixtures/apply-git-patch-from-web-using-init'));
+$I->runComposerCommand('install', ['-vvv']);
+$I->canSeeFileFound('./vendor/cweagans/composer-patches-testrepo/src/OneMoreTest.php');

--- a/tests/unit/CoreDownloaderProviderTest.php
+++ b/tests/unit/CoreDownloaderProviderTest.php
@@ -10,6 +10,7 @@ use Composer\IO\NullIO;
 use Composer\Plugin\PluginInterface;
 use cweagans\Composer\Capability\Downloader\CoreDownloaderProvider;
 use cweagans\Composer\Downloader\ComposerDownloader;
+use cweagans\Composer\Downloader\DownloaderInterface;
 
 class CoreDownloaderProviderTest extends Unit
 {
@@ -27,6 +28,6 @@ class CoreDownloaderProviderTest extends Unit
         $downloaders = $downloaderProvider->getDownloaders();
 
         $this->assertCount(1, $downloaders);
-        $this->assertInstanceOf(ComposerDownloader::class, $downloaders[0]);
+        $this->assertContainsOnlyInstancesOf(DownloaderInterface::class, $downloaders);
     }
 }

--- a/tests/unit/CorePatcherProviderTest.php
+++ b/tests/unit/CorePatcherProviderTest.php
@@ -10,6 +10,7 @@ use Composer\Plugin\PluginInterface;
 use cweagans\Composer\Capability\Patcher\CorePatcherProvider;
 use cweagans\Composer\Patcher\BsdPatchPatcher;
 use cweagans\Composer\Patcher\GitPatcher;
+use cweagans\Composer\Patcher\GitInitPatcher;
 use cweagans\Composer\Patcher\GnuGPatchPatcher;
 use cweagans\Composer\Patcher\GnuPatchPatcher;
 
@@ -25,10 +26,11 @@ class CorePatcherProviderTest extends Unit
 
         $patchers = $patcherProvider->getPatchers();
 
-        $this->assertCount(4, $patchers);
+        $this->assertCount(5, $patchers);
         $this->assertInstanceOf(GitPatcher::class, $patchers[0]);
-        $this->assertInstanceOf(GnuPatchPatcher::class, $patchers[1]);
-        $this->assertInstanceOf(GnuGPatchPatcher::class, $patchers[2]);
-        $this->assertInstanceOf(BsdPatchPatcher::class, $patchers[3]);
+        $this->assertInstanceOf(GitInitPatcher::class, $patchers[1]);
+        $this->assertInstanceOf(GnuPatchPatcher::class, $patchers[2]);
+        $this->assertInstanceOf(GnuGPatchPatcher::class, $patchers[3]);
+        $this->assertInstanceOf(BsdPatchPatcher::class, $patchers[4]);
     }
 }

--- a/tests/unit/CorePatcherProviderTest.php
+++ b/tests/unit/CorePatcherProviderTest.php
@@ -8,6 +8,7 @@ use Composer\Composer;
 use Composer\IO\NullIO;
 use Composer\Plugin\PluginInterface;
 use cweagans\Composer\Capability\Patcher\CorePatcherProvider;
+use cweagans\Composer\Patcher\PatcherInterface;
 use cweagans\Composer\Patcher\BsdPatchPatcher;
 use cweagans\Composer\Patcher\GitPatcher;
 use cweagans\Composer\Patcher\GitInitPatcher;
@@ -27,10 +28,6 @@ class CorePatcherProviderTest extends Unit
         $patchers = $patcherProvider->getPatchers();
 
         $this->assertCount(5, $patchers);
-        $this->assertInstanceOf(GitPatcher::class, $patchers[0]);
-        $this->assertInstanceOf(GitInitPatcher::class, $patchers[1]);
-        $this->assertInstanceOf(GnuPatchPatcher::class, $patchers[2]);
-        $this->assertInstanceOf(GnuGPatchPatcher::class, $patchers[3]);
-        $this->assertInstanceOf(BsdPatchPatcher::class, $patchers[4]);
+        $this->assertContainsOnlyInstancesOf(PatcherInterface::class, $patchers);
     }
 }

--- a/tests/unit/CoreResolverProviderTest.php
+++ b/tests/unit/CoreResolverProviderTest.php
@@ -9,6 +9,7 @@ use Composer\IO\NullIO;
 use Composer\Plugin\PluginInterface;
 use cweagans\Composer\Capability\Resolver\CoreResolverProvider;
 use cweagans\Composer\Resolver\PatchesFile;
+use cweagans\Composer\Resolver\ResolverInterface;
 use cweagans\Composer\Resolver\RootComposer;
 
 class CoreResolverProviderTest extends Unit
@@ -24,7 +25,6 @@ class CoreResolverProviderTest extends Unit
         $resolvers = $resolverProvider->getResolvers();
 
         $this->assertCount(2, $resolvers);
-        $this->assertInstanceOf(RootComposer::class, $resolvers[0]);
-        $this->assertInstanceOf(PatchesFile::class, $resolvers[1]);
+        $this->assertContainsOnlyInstancesOf(ResolverInterface::class, $resolvers);
     }
 }


### PR DESCRIPTION
## Description

`git` has historically been the most reliable mechanism for applying patches. Unfortunately, it doesn't work at all when the target directory isn't a git repo. This pull request adds a new patcher that creates a fake (minimal) git repository in the target directory, uses git to apply the patch, and then cleans up the fake git repo.

## Related tasks

- [x] Documentation has been updated if applicable
- [x] Tests have been added
- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

<!-- Feel free to delete this section if no other information is needed -->

@deviantintegral I'm very curious about your thoughts on this one since you did most of the original debugging around why `git` was misbehaving. (`composer install` then `./vendor/bin/codecept run tests/acceptance/ApplyGitPatchFromWebUsingInitCept.php --debug` if you want to play with this locally)

If this approach works, I'm really considering https://github.com/cweagans/composer-patches/pull/472 as a path forward. Git handles a _lot_ of things that people have asked for over the year. It's also a _lot_ easier to support -- "Go install `git`" is easier to communicate than "Go install `patch`... no, the `patch` that came with your system is unusable and you need to install this other thing that is named exactly the same but provides different functionality"
