### PR TITLE
Issue #490 - Use $COMPOSER environment variable as base for the patches lock file name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,7 +36,7 @@ body:
   - type: textarea
     attributes:
       render: shell
-      label: "Contents of `patches.lock`"
+      label: "Contents of `composer.patches-lock.json`"
     validations:
       required: true
   - type: textarea

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /codeception.yml
 /tests/_data/fixtures/**/vendor/
-/tests/_data/fixtures/**/composer.lock
-/tests/_data/fixtures/**/patches.lock
+/tests/_data/fixtures/**/composer*.lock
+/tests/_data/fixtures/**/*.patches-lock.json
 /tests/_output/
 /tests/_support/_generated/
 /tests/*.suite.yml

--- a/docs/api/composer.patches-lock.json.md
+++ b/docs/api/composer.patches-lock.json.md
@@ -1,12 +1,12 @@
 ---
-title: patches.lock.json
+title: composer.patches-lock.json
 weight: 40
 ---
 
-`patches.lock.json` is the mechanism that Composer Patches now uses to maintain a known-good list of patches to apply to the project. For external projects, the structure of `patches.lock.json` may also be treated as an API. If you're considering `patches.lock.json` as a data source for your project, there are a few things that you should keep in mind:
+`composer.patches-lock.json` is the mechanism that Composer Patches now uses to maintain a known-good list of patches to apply to the project. For external projects, the structure of `composer.patches-lock.json` may also be treated as an API. If you're considering `composer.patches-lock.json` as a data source for your project, there are a few things that you should keep in mind:
 
-* `patches.lock.json` should be considered **read-only** for external uses.
-* The general structure of `patches.lock.json` will not change. You can rely on a JSON file structured like so:
+* `composer.patches-lock.json` should be considered **read-only** for external uses.
+* The general structure of `composer.patches-lock.json` will not change. You can rely on a JSON file structured like so:
 ```json
 {
     "_hash": "[the hash]",

--- a/docs/stork.toml
+++ b/docs/stork.toml
@@ -7,7 +7,7 @@ files = [
     { path = "api/capabilities.md", url = "/api/capabilities/", title = "Capabilities" },
     { path = "api/events.md", url = "/api/events/", title = "Events" },
     { path = "api/overview.md", url = "/api/overview/", title = "Overview" },
-    { path = "api/patches-lock-json.md", url = "/api/patches-lock-json/", title = "patches.lock.json" },
+    { path = "api/composer.patches-lock.json.md", url = "/api/composer-patches-lock-json/", title = "composer.patches-lock.json" },
     { path = "getting-started/installation.md", url = "/getting-started/installation/", title = "Installation" },
     { path = "getting-started/system-requirements.md", url = "/getting-started/system-requirements/", title = "System Requirements" },
     { path = "getting-started/terminology.md", url = "/getting-started/terminology/", title = "Terminology" },

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -6,7 +6,7 @@ weight: 50
 ## `composer patches-relock`
 **Alias**: `composer prl`
 
-`patches-relock` causes the plugin to re-discover all available patches and then write them to the `patches.lock.json` file for your project. This command should be used when changing the list of patches in your project. See the [recommended workflows]({{< relref "recommended-workflows.md" >}}) page for details.
+`patches-relock` causes the plugin to re-discover all available patches and then write them to the `composer.patches-lock.json` file for your project. This command should be used when changing the list of patches in your project. See the [recommended workflows]({{< relref "recommended-workflows.md" >}}) page for details.
 
 ---
 

--- a/docs/usage/defining-patches.md
+++ b/docs/usage/defining-patches.md
@@ -77,7 +77,7 @@ Internally, the plugin uses the expanded format for _all_ patches. Similar to th
 }
 ```
 
-`sha256` can either be specified in your patch definition as above or the sha256 of a patch file will be calculated and written to your `patches.lock.json` file as part of installation.
+`sha256` can either be specified in your patch definition as above or the sha256 of a patch file will be calculated and written to your `composer.patches-lock.json` file as part of installation.
 
 `depth` can be specified on a per-patch basis. If specified, this value overrides any other defaults. If not specified, the first available depth out of the following will be used:
 
@@ -106,7 +106,7 @@ As in previous versions of Composer Patches, you can store patch definitions in 
     }
 }
 ```
-This approach works for many teams, but you should consider moving your patch definitions to a separate `patches.json`. Doing so will mean that you don't have to update `composer.lock` every time you change a patch. Because patch data is locked in `patches.lock.json`, moving the data out of `composer.json` has little downside and can improve your workflow substantially.
+This approach works for many teams, but you should consider moving your patch definitions to a separate `patches.json`. Doing so will mean that you don't have to update `composer.lock` every time you change a patch. Because patch data is locked in `composer.patches-lock.json`, moving the data out of `composer.json` has little downside and can improve your workflow substantially.
 
 ### Patches file
 
@@ -120,8 +120,8 @@ If you're defining patches in `patches.json` (or some other separate patches fil
 }
 ```
 
-## `patches.lock.json`
+## `composer.patches-lock.json`
 
-If `patches.lock.json` does not exist the first time you run `composer install` with this plugin enabled, one will be created for you. Generally, you shouldn't need to do anything with this file: commit it to your project repository alongside your `composer.json` and `composer.lock`, and commit any changes when you change your patch definitions.
+If `composer.patches-lock.json` does not exist the first time you run `composer install` with this plugin enabled, one will be created for you. Generally, you shouldn't need to do anything with this file: commit it to your project repository alongside your `composer.json` and `composer.lock`, and commit any changes when you change your patch definitions.
 
-This file is similar to `composer.lock` in that it includes a `_hash` and the expanded definition for all patches in your project. When `patches.lock.json` exists, patches will be installed from the locked definitions in this file (_instead_ of using the definitions in `composer.json` or elsewhere).
+This file is similar to `composer.lock` in that it includes a `_hash` and the expanded definition for all patches in your project. When `composer.patches-lock.json` exists, patches will be installed from the locked definitions in this file (_instead_ of using the definitions in `composer.json` or elsewhere).

--- a/docs/usage/recommended-workflows.md
+++ b/docs/usage/recommended-workflows.md
@@ -7,17 +7,17 @@ weight: 40
 
 ## Initial setup
 
-The plugin can safely be [installed]({{< relref "../getting-started/installation.md" >}}) as part of initial project setup, even if you don't have any patches to apply right away. A `patches.lock.json` will still be written, but it will be empty.
+The plugin can safely be [installed]({{< relref "../getting-started/installation.md" >}}) as part of initial project setup, even if you don't have any patches to apply right away. A `composer.patches-lock.json` will still be written, but it will be empty.
 
 ## Add a patch to your project
 
 1. [Define a patch]({{< relref "defining-patches.md" >}}) in your `composer.json` or your external patches file (either will work by default, but choose the appropriate place based on how your project is configured).
-2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `patches.lock.json` with your new patch.
+2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `composer.patches-lock.json` with your new patch.
 3. Run [`composer patches-repatch`]({{< relref "commands.md#composer-patches-repatch" >}}) to delete patched dependencies and reinstall them with any defined patches {{< warning title="Running `composer patches-repatch` will delete data" >}}
 Ensure that you don't have any unsaved changes in any patched dependencies in your project.
 {{< /warning >}}
 4. If your patch definition was added to `composer.json`, run `composer update --lock` to update the content hash in `composer.lock`.
-5. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `patches.lock.json`.
+5. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `composer.patches-lock.json`.
 
 ## Apply patches added to the project by someone else
 
@@ -36,12 +36,12 @@ If you're installing the project from scratch:
 ## Remove a patch
 
 1. Delete the patch definition from your `composer.json` or external patches file.
-2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `patches.lock.json` with your new patch.
+2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `composer.patches-lock.json` with your new patch.
 3. Manually delete the dependency that you removed a patch from (the location of the dependency will vary by project, but a good starting point is to look in the `vendor/` directory).
 4. Run [`composer patches-repatch`]({{< relref "commands.md#composer-patches-repatch" >}}) to delete patched dependencies and reinstall them with any defined patches {{< warning title="Running `composer patches-repatch` will delete data" >}}
 Ensure that you don't have any unsaved changes in any patched dependencies in your project.
 {{< /warning >}}
 5. If your patch definition was removed from  `composer.json`, run `composer update --lock` to update the content hash in `composer.lock`.
-6. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `patches.lock.json`.
+6. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `composer.patches-lock.json`.
 
 

--- a/src/Command/RelockCommand.php
+++ b/src/Command/RelockCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace cweagans\Composer\Command;
 
+use cweagans\Composer\Plugin\Patches;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -11,9 +12,11 @@ class RelockCommand extends PatchesCommandBase
 {
     protected function configure(): void
     {
-        $this->setName('patches-relock');
-        $this->setDescription('Find all patches defined in the project and re-write patches.lock.json.');
-        $this->setAliases(['prl']);
+        $file_name = pathinfo(Patches::getPatchesLockFilePath(), \PATHINFO_BASENAME);
+        $this
+            ->setName('patches-relock')
+            ->setDescription("Find all patches defined in the project and re-write $file_name.")
+            ->setAliases(['prl']);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -23,11 +26,13 @@ class RelockCommand extends PatchesCommandBase
             return 1;
         }
 
-        if (file_exists($plugin->getLockFile()->getPath())) {
-            unlink($plugin->getLockFile()->getPath());
+        $file_path = $plugin->getLockFile()->getPath();
+        $file_name = pathinfo($file_path, \PATHINFO_BASENAME);
+        if (file_exists($file_path)) {
+            unlink($file_path);
         }
         $plugin->createNewPatchesLock();
-        $output->write('  - <info>patches.lock.json</info> has been recreated successfully.', true);
+        $output->write("  - <info>$file_name</info> has been recreated successfully.", true);
         return 0;
     }
 }

--- a/src/Locker.php
+++ b/src/Locker.php
@@ -24,7 +24,7 @@ class Locker
     }
 
     /**
-     * Returns the sha256 hash of the sorted content of the patches.lock.json file.
+     * Returns the sha256 hash of the sorted content of the composer.patches-lock.json file.
      *
      * @param PatchCollection $patchCollection
      *   The resolved patches for the project.

--- a/tests/_data/fixtures/commands/composer-a.json
+++ b/tests/_data/fixtures/commands/composer-a.json
@@ -1,0 +1,28 @@
+{
+  "name": "cweagans/composer-patches-test-project",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../../../"
+    }
+  ],
+  "require": {
+    "cweagans/composer-patches": "*@dev",
+    "cweagans/composer-patches-testrepo": "~1.0"
+  },
+  "extra": {
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Change a file": "https://patch-diff.githubusercontent.com/raw/cweagans/composer-patches-testrepo/pull/2.patch"
+      }
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "cweagans/composer-patches": true
+    }
+  }
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -17,7 +17,7 @@ class Acceptance extends Module
         $composerLockFiles = glob($this->_getFixturesDir() . '/*/composer.lock');
         $filesystem->remove($composerLockFiles);
 
-        $patchesLockFiles = glob($this->_getFixturesDir() . '/*/patches.lock.json');
+        $patchesLockFiles = glob($this->_getFixturesDir() . '/*/*.patches-lock.json');
         $filesystem->remove($patchesLockFiles);
 
         $composerVendorDirs = glob($this->_getFixturesDir() . '/*/vendor');

--- a/tests/acceptance/CommandsCept.php
+++ b/tests/acceptance/CommandsCept.php
@@ -11,14 +11,18 @@ $I->wantTo('use composer commands to repatch and relock patch data');
 $I->amInPath(codecept_data_dir('fixtures/commands'));
 $I->runComposerCommand('install', ['-vvv']);
 
-$I->openFile('patches.lock.json');
+$I->openFile('composer.patches-lock.json');
 $I->seeInThisFile('725f2631cb6a92c8c3ffc2e396e89f73b726869131d4c4d2a5903aae6854a260');
 
 $I->runShellCommand('composer patches-relock');
-$I->openFile('patches.lock.json');
+$I->openFile('composer.patches-lock.json');
 $I->seeInThisFile('725f2631cb6a92c8c3ffc2e396e89f73b726869131d4c4d2a5903aae6854a260');
 
 $I->runShellCommand('composer patches-repatch 2>&1');
 $I->canSeeInShellOutput('Removing cweagans/composer-patches-testrepo');
 $I->canSeeInShellOutput('Installing cweagans/composer-patches-testrepo');
 $I->canSeeInShellOutput('Patching cweagans/composer-patches-testrepo');
+
+$I->runShellCommand('COMPOSER="composer-a.json" composer patches-relock');
+$I->openFile('composer-a.patches-lock.json');
+$I->seeInThisFile('fb6848dc544b937ea96b27bd7f9e4f61cc7728582b5e50cb89494b44ea50ae13');


### PR DESCRIPTION
## Description

Relates to/closes #490.

## Related tasks

- [x] Documentation has been updated if applicable
- [x] Tests have been added
- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

About the backwards compatibility: There is no stable 2.x release yet.
