### PR TITLE
Call to undefined method requireComposer()

### DIFF
--- a/src/Command/DoctorCommand.php
+++ b/src/Command/DoctorCommand.php
@@ -28,7 +28,7 @@ class DoctorCommand extends PatchesCommandBase
         }
         $plugin->loadLockedPatches();
 
-        $composer = $this->requireComposer();
+        $composer = $this->getComposer();
         $io = $this->getIO();
         $plugin_manager = $composer->getPluginManager();
         $capabilities = $plugin_manager->getPluginCapabilities(

--- a/src/Command/PatchesCommandBase.php
+++ b/src/Command/PatchesCommandBase.php
@@ -16,7 +16,7 @@ abstract class PatchesCommandBase extends BaseCommand
      */
     protected function getPatchesPluginInstance(): ?Patches
     {
-        foreach ($this->requireComposer()->getPluginManager()->getPlugins() as $plugin) {
+        foreach ($this->getComposer()->getPluginManager()->getPlugins() as $plugin) {
             if ($plugin instanceof Patches) {
                 return $plugin;
             }

--- a/src/Command/RepatchCommand.php
+++ b/src/Command/RepatchCommand.php
@@ -31,7 +31,7 @@ class RepatchCommand extends PatchesCommandBase
             return 1;
         }
 
-        $localRepository = $this->requireComposer()
+        $localRepository = $this->getComposer()
             ->getRepositoryManager()
             ->getLocalRepository();
 
@@ -44,14 +44,14 @@ class RepatchCommand extends PatchesCommandBase
         $promises = [];
         foreach ($packages as $package) {
             $uninstallOperation = new UninstallOperation($package);
-            $promises[] = $this->requireComposer()
+            $promises[] = $this->getComposer()
                 ->getInstallationManager()
                 ->uninstall($localRepository, $uninstallOperation);
         }
         // Wait for uninstalls to finish.
         $promises = array_filter($promises);
         if (!empty($promises)) {
-            $this->requireComposer()->getLoop()->wait($promises);
+            $this->getComposer()->getLoop()->wait($promises);
         }
 
         $input = new ArrayInput(['command' => 'install']);


### PR DESCRIPTION
## Description

fixes e.g. Fatal error: Uncaught Error: Call to undefined method cweagans\Composer\Command\RelockCommand::requireComposer()

## Related tasks

- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).
