### PR TITLE
Properly handle removal of all patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -123,11 +123,6 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         $tmp_patches = $this->arrayMergeRecursiveDistinct($tmp_patches, $patches);
       }
 
-      if ($tmp_patches == FALSE) {
-        $this->io->write('<info>No patches supplied.</info>');
-        return;
-      }
-
       // Remove packages for which the patch set has changed.
       $promises = array();
       foreach ($packages as $package) {


### PR DESCRIPTION
## Description

Currently, if there are no patches provided, we assume that there's
nothing to be done, but that's wrong in case that any installed package
has patches applied, as they need to be re-installed without the
patches now. So the early return needs to be removed.

Fixes #525

## Related tasks

- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).