### PR TITLE
Properly handle all patches being ignored

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -134,7 +134,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
         if (!($package instanceof AliasPackage)) {
           $package_name = $package->getName();
           $extra = $package->getExtra();
-          $has_patches = isset($tmp_patches[$package_name]);
+          $has_patches = isset($tmp_patches[$package_name]) && count($tmp_patches[$package_name]) > 0;
           $has_applied_patches = isset($extra['patches_applied']) && count($extra['patches_applied']) > 0;
           if (($has_patches && !$has_applied_patches)
             || (!$has_patches && $has_applied_patches)


### PR DESCRIPTION
## Description

The check to determine if there are any patches present for a given
package currently yields `true` for an empty set of patches, which can
happen if all patches provided by a package are marked as ignored. This
causes the affected package to be re-installed everytime, because
`$has_patches` is true while `$has_applied_patches` is false. The logic
for `$has_patches` should also check for the number of patches being
greater than 0, just like it is for `$has_applied_patches`.

## Related tasks

- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).