### PR TITLE
FR - Allow version based patches with 2.x.

### DIFF
--- a/src/Patch.php
+++ b/src/Patch.php
@@ -29,6 +29,13 @@ class Patch implements JsonSerializable
     public string $url;
 
     /**
+     * The version of package.
+     *
+     * @var string $version
+     */
+    public string $version;
+
+    /**
      * The sha256 hash of the patch file.
      *
      * @var ?string sha256

--- a/src/Resolver/ResolverBase.php
+++ b/src/Resolver/ResolverBase.php
@@ -94,18 +94,47 @@ abstract class ResolverBase implements ResolverInterface
                 $temporary_patch_list = [];
 
                 foreach ($patch_defs as $description => $url) {
-                    $patch = new Patch();
-                    $patch->package = $package;
-                    $patch->url = $url;
-                    $patch->description = $description;
-
-                    $temporary_patch_list[] = $patch;
+                    if (is_array($url)) {
+                      foreach ($url as $patchdescription => $patchurl) {
+                        $temporary_patch_list[] = $this->getPatches($package, $patchdescription, $patchurl, $description);
+                      }
+                    }
+                    else {
+                      $temporary_patch_list[] = $this->getPatches($package, $description, $url);
+                    }
                 }
-
                 $patches[$package] = $temporary_patch_list;
             }
         }
 
         return $patches;
+    }
+
+    /**
+     * Helper function to create patch object.
+     *
+     * @param array $package
+     *   The package name.
+     * @param array $description
+     *   The patch description.
+     * @param string $url
+     *   The patch url.
+     * @param string $version
+     *   The version of package.
+     *
+     * @return Patch $patches
+     *   An array of Patch objects.
+     */
+    public function getPatches(string $package, string $description, string $url, string $version = ''): Patch
+    {
+        $patch = new Patch();
+        $patch->package = $package;
+        $patch->url = $url;
+        $patch->description = $description;
+        if (!empty($version)) {
+            $patch->version = $version;
+        }
+
+        return $patch;
     }
 }


### PR DESCRIPTION
## Description
Capability to apply version specific patches.

Relates to/closes #issueID.

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes
 example:
```
{
  "patches": {
    "drupal/donotuse": {
      "1.0.8": {
        "Do not use": "https://gist.githubusercontent.com/rajeshreeputra/44c76e98de7831c65a0dcd2558a3129b/raw/b46617ed4c15189e627b69a73d16f383859b9dda/do-not-use-1-0-8.patch"
      },
      "1.0.9": {
        "Do not use": "https://gist.githubusercontent.com/rajeshreeputra/44c76e98de7831c65a0dcd2558a3129b/raw/a041fef3ed7cf22fb7e1dbb366b8d56a72892d07/do-not-use-1-0-9.patch"
      }
    }
  }
}
```

In above example this it applies the first patch when drupal/donotuse is required/updated to 1.0.8 version and second patch applies when drupal/donotuse is required/updated to 1.0.9 version.

**In-progress:**

- [ ] Wildcard version patching like:
   - 1.0.x
   - 1.x
- [ ]  Add test case coverage.