### PR TITLE
Prioritize env vars over composer.json setting

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -287,8 +287,8 @@ class Patches implements PluginInterface, EventSubscriberInterface {
 
     // Check if we should exit in failure.
     $extra = $this->composer->getPackage()->getExtra();
-    $exitOnFailure = getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') || !empty($extra['composer-exit-on-patch-failure']);
-    $skipReporting = getenv('COMPOSER_PATCHES_SKIP_REPORTING') || !empty($extra['composer-patches-skip-reporting']);
+    $exitOnFailure = getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') !== false ? getenv('COMPOSER_EXIT_ON_PATCH_FAILURE') : $extra['composer-exit-on-patch-failure'] ?? false;
+    $skipReporting = getenv('COMPOSER_PATCHES_SKIP_REPORTING') !== false ? getenv('COMPOSER_PATCHES_SKIP_REPORTING') : $extra['composer-patches-skip-reporting'] ?? false;
 
     // Get the package object for the current operation.
     $operation = $event->getOperation();


### PR DESCRIPTION
## Description

Currently, it's impossible to overwrite the composer.json settings `composer-exit-on-patch-failure` and `composer-patches-skip-reporting` with their corresponding env vars.

This PR allows us to easily modify composer-patches behavior, regardless of the settings of the composer.json. This can be very useful in CI pipelines for example.



## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).
