### PR TITLE
Relock patches.lock.json on package install or update

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -320,6 +320,9 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
             return;
         }
 
+        // Relock patches on package install/update.
+        $this->createNewPatchesLock();
+
         // If there aren't any patches, there's nothing to do.
         if (empty($this->patchCollection->getPatchesForPackage($package->getName()))) {
             $this->io->write(


### PR DESCRIPTION
## Description

Relates to/closes #479.

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

<!-- Feel free to delete this section if no other information is needed -->

## Testing steps:
1. Add patch in root composer.json for package "vendor/a" with version 1.0.0
2. Require package using `composer require vendor/a:~1.0.0`
3. Now lock the patches.lock.json file using `composer prl`
4. Now apply patches using `composer prp`
5. Verify patch is applied to package(vendor/a)
6. Now remove patch from root composer.json for package "vendor/a"
7. Now update package using `composer update vendor/a:~1.1.0`
8. Verify that the patches.lock.json file is not updated
9. Verify composer-patches plugin trying to apply the patch to vendor/a package version 1.1.0
10. Now apply changes from [PR](https://github.com/cweagans/composer-patches/pull/553) to composer-patches plugin
11. Now update package using `composer update vendor/a:~1.2.0`
12. Verify that the patches.lock.json file is updated
