### PR TITLE
Made patches.lock.json configurable #533

### DIFF
--- a/docs/api/patches-lock-json.md
+++ b/docs/api/patches-lock-json.md
@@ -4,13 +4,13 @@ weight: 40
 ---
 
 {{< callout title="Filenames may vary in some projects" >}}
-If the [`COMPOSER`]({{< relref "../usage/configuration.md#composer" >}}) environment variable is set when running various Composer Patches commands, the file normally named `patches.lock.json` will be named differently.
+If the [`COMPOSER`]({{< relref "../usage/configuration.md#composer" >}}) environment variable is set when running various Composer Patches commands, the file normally named [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) will be named differently.
 {{< /callout >}}
 
-`patches.lock.json` is the mechanism that Composer Patches now uses to maintain a known-good list of patches to apply to the project. For external projects, the structure of `patches.lock.json` may also be treated as an API. If you're considering `patches.lock.json` as a data source for your project, there are a few things that you should keep in mind:
+[`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) is the mechanism that Composer Patches now uses to maintain a known-good list of patches to apply to the project. For external projects, the structure of [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) may also be treated as an API. If you're considering [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) as a data source for your project, there are a few things that you should keep in mind:
 
-* `patches.lock.json` should be considered **read-only** for external uses.
-* The general structure of `patches.lock.json` will not change. You can rely on a JSON file structured like so:
+* [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) should be considered **read-only** for external uses.
+* The general structure of [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) will not change. You can rely on a JSON file structured like so:
 ```json
 {
     "_hash": "[the hash]",

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -6,7 +6,7 @@ weight: 50
 ## `composer patches-relock`
 **Alias**: `composer prl`
 
-`patches-relock` causes the plugin to re-discover all available patches and then write them to the `patches.lock.json` file for your project. This command should be used when changing the list of patches in your project. See the [recommended workflows]({{< relref "recommended-workflows.md" >}}) page for details.
+`patches-relock` causes the plugin to re-discover all available patches and then write them to the [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) file for your project. This command should be used when changing the list of patches in your project. See the [recommended workflows]({{< relref "recommended-workflows.md" >}}) page for details.
 
 ---
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -28,6 +28,25 @@ Technically, this value can be a path to a file that is nested in a deeper direc
 
 ---
 
+### `patches-lock-file`
+
+```json
+{
+    [...],
+    "extra": {
+        "composer-patches": {
+            "patches-lock-file": "mypatches.lock.json"
+        }
+    }
+}
+```
+
+**Default value**: `patches.lock.json`
+
+`package-depths` allows you to specify overrides for the lockfile name and location.
+
+---
+
 ### `package-depths`
 
 ```json
@@ -215,3 +234,5 @@ COMPOSER=composer-123.json composer install
 The relevant Composer documentation for this parameter can be found [here](https://getcomposer.org/doc/03-cli.md#composer).
 
 Some projects require the use of multiple `composer.json` files (along with their respective `composer.lock` and `patches.lock.json`). Composer Patches will create a different `patches.lock.json` file in the event that this environment variable is set. In the example above, `composer-123-patches.lock.json` would be the lock file that is used for patches.
+
+The lockfile does not follow the `COMPOSER` value when `patches-lock-file` is defined.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -235,4 +235,4 @@ The relevant Composer documentation for this parameter can be found [here](https
 
 Some projects require the use of multiple `composer.json` files (along with their respective `composer.lock` and `patches.lock.json`). Composer Patches will create a different `patches.lock.json` file in the event that this environment variable is set. In the example above, `composer-123-patches.lock.json` would be the lock file that is used for patches.
 
-The lockfile does not follow the `COMPOSER` value when `patches-lock-file` is defined.
+If [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) and `COMPOSER` are both set, the `COMPOSER` value is prepended to the patches lock file name.

--- a/docs/usage/defining-patches.md
+++ b/docs/usage/defining-patches.md
@@ -87,7 +87,7 @@ Internally, the plugin uses the expanded format for _all_ patches. Similar to th
 }
 ```
 
-`sha256` can either be specified in your patch definition as above or the sha256 of a patch file will be calculated and written to your `patches.lock.json` file as part of installation.
+`sha256` can either be specified in your patch definition as above or the sha256 of a patch file will be calculated and written to your [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) file as part of installation.
 
 `depth` can be specified on a per-patch basis. If specified, this value overrides any other defaults. If not specified, the first available depth out of the following will be used:
 
@@ -116,7 +116,7 @@ As in previous versions of Composer Patches, you can store patch definitions in 
     }
 }
 ```
-This approach works for many teams, but you should consider moving your patch definitions to a separate `patches.json`. Doing so will mean that you don't have to update `composer.lock` every time you change a patch. Because patch data is locked in `patches.lock.json`, moving the data out of `composer.json` has little downside and can improve your workflow substantially.
+This approach works for many teams, but you should consider moving your patch definitions to a separate `patches.json`. Doing so will mean that you don't have to update `composer.lock` every time you change a patch. Because patch data is locked in [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}), moving the data out of `composer.json` has little downside and can improve your workflow substantially.
 
 ### Patches file
 
@@ -151,3 +151,5 @@ If the same patch is defined in multiple places, the first one added to the patc
 If `patches.lock.json` does not exist the first time you run `composer install` with this plugin enabled, one will be created for you. Generally, you shouldn't need to do anything with this file: commit it to your project repository alongside your `composer.json` and `composer.lock`, and commit any changes when you change your patch definitions.
 
 This file is similar to `composer.lock` in that it includes a `_hash` and the expanded definition for all patches in your project. When `patches.lock.json` exists, patches will be installed from the locked definitions in this file (_instead_ of using the definitions in `composer.json` or elsewhere).
+
+The file location and name can be replaced by the option [`patches-lock-file`]({{< relref "../usage/configuration.md#patches-lock-file" >}}).

--- a/docs/usage/recommended-workflows.md
+++ b/docs/usage/recommended-workflows.md
@@ -7,17 +7,17 @@ weight: 40
 
 ## Initial setup
 
-The plugin can safely be [installed]({{< relref "../getting-started/installation.md" >}}) as part of initial project setup, even if you don't have any patches to apply right away. A `patches.lock.json` will still be written, but it will be empty.
+The plugin can safely be [installed]({{< relref "../getting-started/installation.md" >}}) as part of initial project setup, even if you don't have any patches to apply right away. A [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) will still be written, but it will be empty.
 
 ## Add a patch to your project
 
 1. [Define a patch]({{< relref "defining-patches.md" >}}) in your `composer.json` or your external patches file (either will work by default, but choose the appropriate place based on how your project is configured).
-2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `patches.lock.json` with your new patch.
+2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) with your new patch.
 3. Run [`composer patches-repatch`]({{< relref "commands.md#composer-patches-repatch" >}}) to delete patched dependencies and reinstall them with any defined patches {{< warning title="Running `composer patches-repatch` will delete data" >}}
 Ensure that you don't have any unsaved changes in any patched dependencies in your project.
 {{< /warning >}}
 4. If your patch definition was added to `composer.json`, run `composer update --lock` to update the content hash in `composer.lock`.
-5. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `patches.lock.json`.
+5. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}).
 
 ## Apply patches added to the project by someone else
 
@@ -36,12 +36,12 @@ If you're installing the project from scratch:
 ## Remove a patch
 
 1. Delete the patch definition from your `composer.json` or external patches file.
-2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate `patches.lock.json` with your new patch.
+2. Run [`composer patches-relock`]({{< relref "commands.md#composer-patches-relock" >}}) to regenerate [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}) with your new patch.
 3. Manually delete the dependency that you removed a patch from (the location of the dependency will vary by project, but a good starting point is to look in the `vendor/` directory).
 4. Run [`composer patches-repatch`]({{< relref "commands.md#composer-patches-repatch" >}}) to delete patched dependencies and reinstall them with any defined patches {{< warning title="Running `composer patches-repatch` will delete data" >}}
 Ensure that you don't have any unsaved changes in any patched dependencies in your project.
 {{< /warning >}}
 5. If your patch definition was removed from  `composer.json`, run `composer update --lock` to update the content hash in `composer.lock`.
-6. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and `patches.lock.json`.
+6. Commit any related changes to your external patches file (if configured), `composer.json`, `composer.lock`, and [`patches.lock.json`]({{< relref "../usage/configuration.md#patches-lock-file" >}}).
 
 

--- a/src/Command/RelockCommand.php
+++ b/src/Command/RelockCommand.php
@@ -13,7 +13,9 @@ class RelockCommand extends PatchesCommandBase
     protected function configure(): void
     {
         $this->setName('patches-relock');
-        $filename = pathinfo(Patches::getPatchesLockFilePath(), \PATHINFO_BASENAME);
+        $plugin = $this->getPatchesPluginInstance();
+
+        $filename = pathinfo($plugin->getPatchesLockFilePath(), \PATHINFO_BASENAME);
         $this->setDescription("Find all patches defined in the project and re-write $filename.");
         $this->setAliases(['prl']);
     }
@@ -29,7 +31,7 @@ class RelockCommand extends PatchesCommandBase
             unlink($plugin->getLockFile()->getPath());
         }
         $plugin->createNewPatchesLock();
-        $output->write('  - <info>patches.lock.json</info> has been recreated successfully.', true);
+        $output->write("  - <info>{$plugin->getPatchesLockFilePath()}</info> has been recreated successfully.", true);
         return 0;
     }
 }

--- a/src/Command/RelockCommand.php
+++ b/src/Command/RelockCommand.php
@@ -13,10 +13,7 @@ class RelockCommand extends PatchesCommandBase
     protected function configure(): void
     {
         $this->setName('patches-relock');
-        $plugin = $this->getPatchesPluginInstance();
-
-        $filename = pathinfo($plugin->getPatchesLockFilePath(), \PATHINFO_BASENAME);
-        $this->setDescription("Find all patches defined in the project and re-write $filename.");
+        $this->setDescription("Find all patches defined in the project and re-write the patches lock file.");
         $this->setAliases(['prl']);
     }
 
@@ -31,7 +28,8 @@ class RelockCommand extends PatchesCommandBase
             unlink($plugin->getLockFile()->getPath());
         }
         $plugin->createNewPatchesLock();
-        $output->write("  - <info>{$plugin->getPatchesLockFilePath()}</info> has been recreated successfully.", true);
+        $filename = pathinfo($plugin->getPatchesLockFilePath(), \PATHINFO_BASENAME);
+        $output->write("  - <info>$filename</info> has been recreated successfully.", true);
         return 0;
     }
 }

--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -152,9 +152,6 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
         $base = pathinfo($composer_file, \PATHINFO_FILENAME);
 
         $lock_file = $this->getConfig('patches-lock-file');
-        if (!is_string($lock_file)) {
-            $lock_file = 'patches-lock-file';
-        }
 
         if ($base === 'composer') {
             return "$dir/$lock_file";

--- a/tests/unit/PatchesPluginTest.php
+++ b/tests/unit/PatchesPluginTest.php
@@ -40,7 +40,14 @@ class PatchesPluginTest extends Unit
      */
     public function testGetPatchesLockFilePath()
     {
+        $package = new RootPackage('cweagans/composer-patches', '0.0.0.0', '0.0.0');
+        $io = new NullIO();
+        $composer = new Composer();
+        $composer->setPackage($package);
+
         $plugin = new Patches();
+        $plugin->activate($composer, $io);
+
         $path = $plugin->getPatchesLockFilePath();
         $filename = pathinfo($path, \PATHINFO_BASENAME);
         $this->assertEquals('patches.lock.json', $filename);

--- a/tests/unit/PatchesPluginTest.php
+++ b/tests/unit/PatchesPluginTest.php
@@ -40,12 +40,13 @@ class PatchesPluginTest extends Unit
      */
     public function testGetPatchesLockFilePath()
     {
-        $path = Patches::getPatchesLockFilePath();
+        $plugin = new Patches();
+        $path = $plugin->getPatchesLockFilePath();
         $filename = pathinfo($path, \PATHINFO_BASENAME);
         $this->assertEquals('patches.lock.json', $filename);
 
         putenv('COMPOSER=mycomposer.json');
-        $path = Patches::getPatchesLockFilePath();
+        $path = $plugin->getPatchesLockFilePath();
         $filename = pathinfo($path, \PATHINFO_BASENAME);
         $this->assertEquals('mycomposer-patches.lock.json', $filename);
     }

--- a/tests/unit/PatchesPluginTest.php
+++ b/tests/unit/PatchesPluginTest.php
@@ -18,6 +18,15 @@ use cweagans\Composer\Plugin\Patches;
 class PatchesPluginTest extends Unit
 {
     /**
+     * Reset `COMPSER` env value after each test to prevent contamination.
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv('COMPOSER=');
+    }
+
+    /**
      * Test plugin activation.
      *
      * Despite not actually asserting anything, this test ensures that if the
@@ -56,6 +65,35 @@ class PatchesPluginTest extends Unit
         $path = $plugin->getPatchesLockFilePath();
         $filename = pathinfo($path, \PATHINFO_BASENAME);
         $this->assertEquals('mycomposer-patches.lock.json', $filename);
+    }
+
+    /**
+     * Test that override patches-lock-file file does apply.
+     */
+    public function testConfigurePatchesLockFilePath()
+    {
+        $package = new RootPackage('cweagans/composer-patches', '0.0.0.0', '0.0.0');
+        $package->setExtra([
+            'composer-patches' => [
+                'patches-lock-file' => 'test-patches.lock.json',
+            ],
+        ]);
+
+        $io = new NullIO();
+        $composer = new Composer();
+        $composer->setPackage($package);
+
+        $plugin = new Patches();
+        $plugin->activate($composer, $io);
+
+        $path = $plugin->getPatchesLockFilePath();
+        $filename = pathinfo($path, \PATHINFO_BASENAME);
+        $this->assertEquals('test-patches.lock.json', $filename);
+
+        putenv('COMPOSER=mycomposer.json');
+        $path = $plugin->getPatchesLockFilePath();
+        $filename = pathinfo($path, \PATHINFO_BASENAME);
+        $this->assertEquals('mycomposer-test-patches.lock.json', $filename);
     }
 
     /**


### PR DESCRIPTION
## Description

Relates to/closes #533

## Related tasks

- [x] Documentation has been updated if applicable
- [x] Tests have been added
- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

I'm new to the composer-plugin world, so have no clue that this is even the correct path.
Before writing docs and tests can someone confirm this is the correct path?
