### PR TITLE
Patching fails when --no-cache is passed

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -26,7 +26,16 @@ class Downloader
         $this->io = $io;
         $this->disabledDownloaders = $disabledDownloaders;
 
-        $this->cacheDir = $composer->getConfig()->get('cache-dir') . '/patches';
+        // If --no-cache is passed to Composer, we need a different location to
+        // download patches to. When --no-cache is passed, $composer_cache is
+        // set to /dev/null.
+        $composer_cache = $composer->getConfig()->get('cache-dir');
+        if (!is_dir($composer_cache)) {
+            $composer_cache = sys_get_temp_dir();
+        }
+
+        // If the cache directory doesn't exist, create it.
+        $this->cacheDir = $composer_cache . '/patches';
         if (!is_dir($this->cacheDir)) {
             mkdir($this->cacheDir);
         }

--- a/tests/_data/fixtures/apply-git-patch-from-web-no-cache/composer.json
+++ b/tests/_data/fixtures/apply-git-patch-from-web-no-cache/composer.json
@@ -1,0 +1,29 @@
+{
+  "name": "cweagans/composer-patches-test-project",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../../../"
+    }
+  ],
+  "require": {
+    "cweagans/composer-patches": "*@dev",
+    "cweagans/composer-patches-testrepo": "~1.0"
+  },
+  "extra": {
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Add a file": "https://patch-diff.githubusercontent.com/raw/cweagans/composer-patches-testrepo/pull/1.patch"
+      }
+    }
+  },
+  "config": {
+    "preferred-install": "source",
+    "allow-plugins": {
+      "cweagans/composer-patches": true
+    }
+  }
+}

--- a/tests/acceptance/ApplyGitPatchFromWebNoCacheCept.php
+++ b/tests/acceptance/ApplyGitPatchFromWebNoCacheCept.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @var \Codeception\Scenario $scenario
+ */
+
+use cweagans\Composer\Tests\AcceptanceTester;
+
+$I = new AcceptanceTester($scenario);
+$I->wantTo('modify a package using a patch downloaded from the internet (with "composer --no-cache")');
+$I->amInPath(codecept_data_dir('fixtures/apply-git-patch-from-web-no-cache'));
+$I->runComposerCommand('install', ['-vvv', '--no-cache']);
+$I->canSeeFileFound('./vendor/cweagans/composer-patches-testrepo/src/OneMoreTest.php');


### PR DESCRIPTION
## Description

Relates to/closes #608.

## Related tasks

- [x] Documentation has been updated if applicable
- [x] Tests have been added
- [x] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

<!-- Feel free to delete this section if no other information is needed -->
