### PR TITLE
Report if 'patch' command does not exist.

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -422,6 +422,9 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     // If the patch *still* isn't applied, then give up and throw an Exception.
     // Otherwise, let the user know it worked.
     if (!$patched) {
+      if (!$this->executeCommand("command -v patch")) {
+        throw new \Exception("The 'patch' command does not exist. Cannot apply the patch $patch_url.");;
+      }
       throw new \Exception("Cannot apply patch $patch_url");
     }
   }


### PR DESCRIPTION
## Description

Report if 'patch' command does not exist.

## Related tasks

(this needs to be refined a bit, I think.)

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

See e.g. https://github.com/ddev/ddev/issues/809
For me this happened when suddenly patches no longer applied, and my first assumption was that my patches are no longer compatible. Instead, the updated ddev web package no longer had 'patch' command available.
