### PR TITLE
Fix freeform patcher applying patch during dry run

### DIFF
--- a/src/Patcher/FreeformPatcher.php
+++ b/src/Patcher/FreeformPatcher.php
@@ -29,7 +29,7 @@ class FreeformPatcher extends PatcherBase
         // If we have dry-run args, do a dry-run.
         if (!empty($dryRunArgs)) {
             $status = $this->executeCommand(
-                '%s ' . $args,
+                '%s ' . $dryRunArgs,
                 $patchTool,
                 $patch->depth,
                 $path,


### PR DESCRIPTION
## Description

The freeform patcher was using the regular args for the dry run instead of the dry run args. If dry run args were provided, the patch was applied twice.