### PR TITLE
Multiple patch listing files

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -146,6 +146,10 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
                 'type' => 'string',
                 'default' => 'patches.json',
             ],
+            'patch-files' => [
+                'type' => 'list',
+                'default' => [],
+            ],
             "ignore-dependency-patches" => [
                 'type' => 'list',
                 'default' => [],


### PR DESCRIPTION
## Description
No issue... maybe I should've written an issue before a PR? (but .github/CONTRIBUTING.md is empty so unsure).

Upgrading a pile of Drupal sites to PHP 8.5. Almost all of them need the same 4-8 patches. Most of them still have some PHP 8.4 related patches. Having to merge JSON manually for each site is more work than I think needed. Instead, I want to have multiple patches files...

patches.json (or whatever name) with site specific patches
php84.patches.json with PHP 8.4 related patches for components that most of my sites have
php85.patches.json with PHP 8.5 related patches for common components.

Because packages in the patch file that don't exist on the project are silently ignored that is really convenient and reduces work on similar projects.

Example output:
<img width="777" height="138" alt="image" src="https://github.com/user-attachments/assets/b789cb9c-4da6-4415-8d0a-4d3e2e462c79" />


## Related tasks
_Everything here needs to be done if the idea is approved - happy to do so, but wanted to get a POC out for my own personal use/testing_
- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s). -- in current patch I am messaging that current `patches-file` config key is deprecated. But that should probably be discussed.
