### PR TITLE
Add a PatchPatcher plugin

### DIFF
--- a/src/Capability/Patcher/CorePatcherProvider.php
+++ b/src/Capability/Patcher/CorePatcherProvider.php
@@ -5,6 +5,7 @@ namespace cweagans\Composer\Capability\Patcher;
 use cweagans\Composer\Patcher\FreeformPatcher;
 use cweagans\Composer\Patcher\GitPatcher;
 use cweagans\Composer\Patcher\GitInitPatcher;
+use cweagans\Composer\Patcher\PatchPatcher;
 
 class CorePatcherProvider extends BasePatcherProvider
 {
@@ -16,7 +17,8 @@ class CorePatcherProvider extends BasePatcherProvider
         return [
             new GitPatcher($this->composer, $this->io, $this->plugin),
             new GitInitPatcher($this->composer, $this->io, $this->plugin),
-            new FreeformPatcher($this->composer, $this->io, $this->plugin)
+            new FreeformPatcher($this->composer, $this->io, $this->plugin).
+            new PatchPatcher($this->composer, $this->io, $this->plugin)
         ];
     }
 }

--- a/src/Patcher/PatchPatcher.php
+++ b/src/Patcher/PatchPatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace cweagans\Composer\Patcher;
+
+use cweagans\Composer\Patch;
+use Composer\IO\IOInterface;
+
+class PatchPatcher extends PatcherBase
+{
+  protected string $tool = 'patch';
+
+  public function apply(Patch $patch, string $path): bool
+  {
+    // Dry run first.
+    $status = $this->executeCommand(
+      "sh -lc '%s -p%s --dry-run --no-backup-if-mismatch -d %s < %s'",
+      $this->patchTool(),
+      $patch->depth,
+      $path,
+      $patch->localPath
+    );
+
+    // If the check failed, then don't proceed with actually applying the patch.
+    if (!$status) {
+      return false;
+    }
+
+    // Otherwise, we can try to apply the patch.
+    return $this->executeCommand(
+      "sh -lc '%s -p%s --no-backup-if-mismatch -d %s < %s'",
+      $this->patchTool(),
+      $patch->depth,
+      $path,
+      $patch->localPath
+    );
+  }
+
+  public function canUse(): bool
+  {
+    $output = '';
+    $result = $this->executor->execute($this->patchTool() . ' --version', $output);
+    return ($result === 0);
+  }
+}


### PR DESCRIPTION
## Description

Closes #677

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

## Other notes

<!-- Feel free to delete this section if no other information is needed -->

This is a first draft, this needs to be discussed thoroughly with the maintainers. Biggest issues is: the plugin probably shouldn't be enabled by default as it contradicts having `patch` removed excplicitly in composer-patches v2.
