### PR TITLE
Fix Issue #626: patches-repatch has return code 0 even when patch fails

### DIFF
--- a/src/Plugin/Patches.php
+++ b/src/Plugin/Patches.php
@@ -358,7 +358,13 @@ class Patches implements PluginInterface, EventSubscriberInterface, Capable
                 IOInterface::DEBUG
             );
 
-            $this->apply($patch, $install_path);
+            try {
+                $this->apply($patch, $install_path);
+            }
+            catch (Exception $e) {
+                $this->io->write("<error>{$e->getMessage()}</error>");
+                exit(1);
+            }
         }
 
         $this->io->write(


### PR DESCRIPTION
Catch the exception from ::apply() and exit immediately with a non-zero return code.

## Description

Closes #626

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).