### PR TITLE
Remove trailing slash from `sys_get_temp_dir()` result

### DIFF
--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -31,7 +31,7 @@ class Downloader
         // set to /dev/null.
         $composer_cache = $composer->getConfig()->get('cache-dir');
         if (!is_dir($composer_cache)) {
-            $composer_cache = sys_get_temp_dir();
+            $composer_cache = rtrim(sys_get_temp_dir(), '/');
         }
 
         // If the cache directory doesn't exist, create it.

--- a/src/Downloader/ComposerDownloader.php
+++ b/src/Downloader/ComposerDownloader.php
@@ -23,7 +23,7 @@ class ComposerDownloader extends DownloaderBase
             return;
         }
 
-        $patches_dir = sys_get_temp_dir() . '/composer-patches/';
+        $patches_dir = rtrim(sys_get_temp_dir(), '/') . '/composer-patches/';
         $filename = uniqid($patches_dir) . ".patch";
         if (!is_dir($patches_dir)) {
             mkdir($patches_dir);

--- a/tests/unit/ComposerDownloaderTest.php
+++ b/tests/unit/ComposerDownloaderTest.php
@@ -11,7 +11,6 @@ use Composer\Plugin\PluginInterface;
 use cweagans\Composer\Downloader\ComposerDownloader;
 use cweagans\Composer\Downloader\Exception\HashMismatchException;
 use cweagans\Composer\Patch;
-use cweagans\Composer\Plugin\Patches;
 
 class ComposerDownloaderTest extends Unit
 {
@@ -20,7 +19,7 @@ class ComposerDownloaderTest extends Unit
         parent::setUp();
 
         // Needed so we get full coverage in the ComposerDownloader class.
-        $patches_dir = sys_get_temp_dir() . '/composer-patches/';
+        $patches_dir = rtrim(sys_get_temp_dir(), '/') . '/composer-patches/';
         if (is_dir($patches_dir)) {
             foreach (glob($patches_dir . '*.patch') as $patch) {
                 unlink($patch);


### PR DESCRIPTION
## Description

On some environments `sys_get_temp_dir()` may return path with trailing shlash. This is a little inconsistent accross diferent systems and it is mentioned in comments on https://www.php.net/manual/en/function.sys-get-temp-dir.php. 

I also encountered this error on one of the servers (OpenBSD based):

```
In Downloader.php line 78:
                                                                                                                                        
  [ErrorException]                                                                                                                      
  rename(/tmp//composer-patches/698a01bfa25ae.patch,/home/xxx/.composer/cache/patches/c5cad8cb941b6d2be7d70b55760ccd5c97a8128a0c838  
  0ceb54c099034d7ec81.patch): Operation not permitted  
```

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).
